### PR TITLE
ACBS: Introduce AB3 Stage 2 support

### DIFF
--- a/acbs/ab3cfg.py
+++ b/acbs/ab3cfg.py
@@ -1,0 +1,42 @@
+import os
+
+from acbs import bashvar
+
+class AB3Cfg(object):
+
+    def __init__(self, path) -> None:
+        '''
+        Class representing autobuild3 config file.
+
+        :param path: path to the ab3cfg.sh file, with the filename
+        '''
+        self.cfgpath = path
+        self.file = None
+        self.vars = None
+        self.stage2 = False
+        try:
+            self.file = open(self.cfgpath, 'rt')
+        except IOError:
+            # You run ACBS then you should have AB3, eh?
+            raise RuntimeError(f'Autobuild3 config file {self.cfgpath} does not exist\n' +
+                               'Unable to read Autobuild3 config file.')
+        if self.file:
+            self.parse()
+
+    def parse(self):
+        '''
+        Parse the ab3cfg.sh file.
+        '''
+        if self.file:
+            try:
+                self.vars = bashvar.eval_bashvar(self.file.read(), filename=self.cfgpath)
+            except Exception as e:
+                raise RuntimeError(f'Error parsing autobuild3 config file: {e}.')
+
+    def is_in_stage2(self) -> bool:
+        '''
+        Return True if ab3 is in stage 2 mode.
+        '''
+        if self.vars:
+            self.stage2 = ((self.vars.get('ABSTAGE2') == '1') or False)
+        return self.stage2

--- a/acbs/ab3cfg.py
+++ b/acbs/ab3cfg.py
@@ -1,39 +1,20 @@
 import os
 
+from acbs.const import AUTOBUILD_CONF_DIR
 from acbs import bashvar
+from pyparsing import ParseException # type: ignore
 
-class AB3Cfg(object):
 
-    def __init__(self, path) -> None:
-        '''
-        Class representing autobuild3 config file.
-
-        :param path: path to the ab3cfg.sh file, with the filename
-        '''
-        self.cfgpath = path
-        self.vars = None
-        self.stage2 = False
-        try:
-            with open(self.cfgpath, 'rt') as cfgfile:
-                self.parse(cfgfile)
-        except Exception as e:
-            # You run ACBS then you should have AB3, eh?
-            raise RuntimeError(f'Autobuild3 config file {self.cfgpath} does not exist\n' +
-                               'Unable to read Autobuild3 config file.') from e
-
-    def parse(self, file):
-        '''
-        Parse the ab3cfg.sh file.
-        '''
-        try:
-            self.vars = bashvar.eval_bashvar(file.read(), filename=self.cfgpath)
-        except Exception as e:
-            raise RuntimeError(f'Error parsing autobuild3 config file: {e}.') from e
-
-    def is_in_stage2(self) -> bool:
-        '''
-        Return True if ab3 is in stage 2 mode.
-        '''
-        if self.vars:
-            self.stage2 = ((self.vars.get('ABSTAGE2') == '1') or False)
-        return self.stage2
+def is_in_stage2() -> bool:
+    ab3cfg_path: str = os.path.join(AUTOBUILD_CONF_DIR, 'ab3cfg.sh')
+    try:
+        with open(ab3cfg_path) as f:
+            vars = bashvar.eval_bashvar(f.read(), filename=ab3cfg_path)
+            stage2_val: str = vars.get('ABSTAGE2')
+            return True if stage2_val == '1' else False
+    except OSError as e:
+        raise RuntimeError(f'Unable to read Autobuild config file {ab3cfg_path}.') from e
+    except ParseException as e:
+        raise RuntimeError(f'Error occurred while parsing Autobuild config file {ab3cfg_path}.') from e
+    except Exception as e:
+        raise RuntimeError(f'Error occurred while checking whether stage 2 mode is enabled.') from e

--- a/acbs/ab3cfg.py
+++ b/acbs/ab3cfg.py
@@ -11,7 +11,7 @@ def is_in_stage2() -> bool:
         with open(ab3cfg_path) as f:
             vars = bashvar.eval_bashvar(f.read(), filename=ab3cfg_path)
             stage2_val: str = vars.get('ABSTAGE2')
-            return True if stage2_val == '1' else False
+            return stage2_val == '1'
     except OSError as e:
         raise RuntimeError(f'Unable to read Autobuild config file {ab3cfg_path}.') from e
     except ParseException as e:

--- a/acbs/ab3cfg.py
+++ b/acbs/ab3cfg.py
@@ -11,27 +11,24 @@ class AB3Cfg(object):
         :param path: path to the ab3cfg.sh file, with the filename
         '''
         self.cfgpath = path
-        self.file = None
         self.vars = None
         self.stage2 = False
         try:
-            self.file = open(self.cfgpath, 'rt')
-        except IOError:
+            with open(self.cfgpath, 'rt') as cfgfile:
+                self.parse(cfgfile)
+        except Exception as e:
             # You run ACBS then you should have AB3, eh?
             raise RuntimeError(f'Autobuild3 config file {self.cfgpath} does not exist\n' +
-                               'Unable to read Autobuild3 config file.')
-        if self.file:
-            self.parse()
+                               'Unable to read Autobuild3 config file.') from e
 
-    def parse(self):
+    def parse(self, file):
         '''
         Parse the ab3cfg.sh file.
         '''
-        if self.file:
-            try:
-                self.vars = bashvar.eval_bashvar(self.file.read(), filename=self.cfgpath)
-            except Exception as e:
-                raise RuntimeError(f'Error parsing autobuild3 config file: {e}.')
+        try:
+            self.vars = bashvar.eval_bashvar(file.read(), filename=self.cfgpath)
+        except Exception as e:
+            raise RuntimeError(f'Error parsing autobuild3 config file: {e}.') from e
 
     def is_in_stage2(self) -> bool:
         '''

--- a/acbs/const.py
+++ b/acbs/const.py
@@ -14,6 +14,7 @@ ANSI_BROWN = '\033[33m'
 
 # Common paths
 CONF_DIR = '/etc/acbs/'
+AUTOBUILD_CONF_DIR = '/etc/autobuild/'
 DUMP_DIR = '/var/cache/acbs/tarballs/'
 TMP_DIR = '/var/cache/acbs/build/'
 LOG_DIR = '/var/log/acbs/'

--- a/acbs/deps.py
+++ b/acbs/deps.py
@@ -55,7 +55,7 @@ def strongly_connected(search_path: str, packages_list: List[str], results: list
     stack.append(vert)
 
     # search package begin
-    print(f'[{len(results) + 1}/{len(pool)}] {vert}\t\t\r', end='', flush=True)
+    print(f'[{len(results) + 1}/{len(pool)}] {vert:30}\r', end='', flush=True)
     current_package = packages.get(vert)
     if current_package is None:
         package = pool.get(vert) or find_package(vert, search_path, stage2)

--- a/acbs/deps.py
+++ b/acbs/deps.py
@@ -8,7 +8,7 @@ from acbs.parser import ACBSPackageInfo, check_buildability
 pool: Dict[str, ACBSPackageInfo] = {}
 
 
-def tarjan_search(packages: 'OrderedDict[str, ACBSPackageInfo]', search_path: str) -> List[List[ACBSPackageInfo]]:
+def tarjan_search(packages: 'OrderedDict[str, ACBSPackageInfo]', search_path: str, stage2: bool) -> List[List[ACBSPackageInfo]]:
     """This function describes a Tarjan's strongly connected components algorithm.
     The resulting list of ACBSPackageInfo are sorted topologically as a byproduct of the algorithm
     """
@@ -23,7 +23,7 @@ def tarjan_search(packages: 'OrderedDict[str, ACBSPackageInfo]', search_path: st
     for i in packages_list:
         if index[i] == -1:  # recurse on each package that is not yet visited
             strongly_connected(search_path, packages_list, results, packages,
-                               i, lowlink, index, stackstate, stack)
+                               i, lowlink, index, stackstate, stack, stage2)
     return results
 
 
@@ -46,7 +46,7 @@ def prepare_for_reorder(package: ACBSPackageInfo, packages_list: List[str]) -> A
     return package
 
 
-def strongly_connected(search_path: str, packages_list: List[str], results: list, packages: 'OrderedDict[str, ACBSPackageInfo]', vert: str, lowlink: Dict[str, int], index: Dict[str, int], stackstate: Dict[str, bool], stack: Deque[str], depth=0):
+def strongly_connected(search_path: str, packages_list: List[str], results: list, packages: 'OrderedDict[str, ACBSPackageInfo]', vert: str, lowlink: Dict[str, int], index: Dict[str, int], stackstate: Dict[str, bool], stack: Deque[str], stage2: bool, depth=0):
     # update depth indices
     index[vert] = depth
     lowlink[vert] = depth
@@ -58,7 +58,7 @@ def strongly_connected(search_path: str, packages_list: List[str], results: list
     print(f'[{len(results) + 1}/{len(pool)}] {vert}\t\t\r', end='', flush=True)
     current_package = packages.get(vert)
     if current_package is None:
-        package = pool.get(vert) or find_package(vert, search_path)
+        package = pool.get(vert) or find_package(vert, search_path, stage2)
         if not package:
             raise ValueError(
                 f'Package {vert} not found')

--- a/acbs/find.py
+++ b/acbs/find.py
@@ -59,17 +59,17 @@ def find_package(name: str, search_path: str, stage2: bool) -> List[ACBSPackageI
             p = p.strip()
             if not p or p.startswith('#'):
                 continue
-            found = find_package_inner(p, search_path, stage2)
+            found = find_package_inner(p, search_path, stage2=stage2)
             if not found:
                 raise RuntimeError(
                     f'Package {p} requested in {name} was not found.')
             results.extend(found)
         print()
         return results
-    return find_package_inner(name, search_path, stage2)
+    return find_package_inner(name, search_path, stage2=stage2)
 
 
-def find_package_inner(name: str, search_path: str, stage2: bool, group=False) -> List[ACBSPackageInfo]:
+def find_package_inner(name: str, search_path: str, group=False, stage2: bool=False) -> List[ACBSPackageInfo]:
     if os.path.isdir(os.path.join(search_path, name)):
         flat_path = os.path.join(search_path, name, 'autobuild')
         if os.path.isdir(flat_path):

--- a/acbs/find.py
+++ b/acbs/find.py
@@ -55,7 +55,7 @@ def find_package(name: str, search_path: str, stage2: bool) -> List[ACBSPackageI
         results = []
         print()
         for n, p in enumerate(packages):
-            print(f'[{n + 1}/{len(packages)}] {name} > {p}{" " * 15}\r', end='', flush=True)
+            print(f'[{n + 1}/{len(packages)}] {name} > {p:15}\r', end='', flush=True)
             p = p.strip()
             if not p or p.startswith('#'):
                 continue

--- a/acbs/find.py
+++ b/acbs/find.py
@@ -6,12 +6,12 @@ from acbs.parser import parse_package, ACBSPackageInfo, ACBSSourceInfo
 from acbs.utils import make_build_dir
 
 
-def check_package_group(name: str, search_path: str, entry_path: str, stage2=False) -> Optional[List[ACBSPackageInfo]]:
+def check_package_group(name: str, search_path: str, entry_path: str, stage2: bool) -> Optional[List[ACBSPackageInfo]]:
     # is this a package group?
     if os.path.basename(entry_path) == os.path.basename(name) and os.path.isfile(os.path.join(search_path, entry_path, 'spec')):
         stub = ACBSPackageInfo(name, [], '', [ACBSSourceInfo('none', '', '')])
         stub.base_slug = entry_path
-        return expand_package_group(stub, search_path, stage2=stage2)
+        return expand_package_group(stub, search_path, stage2)
     with os.scandir(os.path.join(search_path, entry_path)) as group:
         # scan potential package groups
         for entry_group in group:
@@ -23,7 +23,7 @@ def check_package_group(name: str, search_path: str, entry_path: str, stage2=Fal
                 continue
             # because the package inside the group will have a different name than the folder name
             # we will parse the defines file to decide
-            result = parse_package(full_search_path, stage2=stage2)
+            result = parse_package(full_search_path, stage2)
             if result and result.name == name:
                 # name of the package inside the group
                 package_alias = os.path.basename(
@@ -42,12 +42,12 @@ def check_package_group(name: str, search_path: str, entry_path: str, stage2=Fal
                     group_category), root=os.path.basename(group_root))
                 result.group_seq = group_seq
                 group_result = expand_package_group(
-                    result, search_path, stage2=stage2)
+                    result, search_path, stage2)
                 return group_result
     return None
 
 
-def find_package(name: str, search_path: str, stage2=False) -> List[ACBSPackageInfo]:
+def find_package(name: str, search_path: str, stage2: bool) -> List[ACBSPackageInfo]:
     if os.path.isfile(os.path.join(search_path, name)):
         with open(os.path.join(search_path, name), 'rt') as f:
             content = f.read()
@@ -59,23 +59,23 @@ def find_package(name: str, search_path: str, stage2=False) -> List[ACBSPackageI
             p = p.strip()
             if not p or p.startswith('#'):
                 continue
-            found = find_package_inner(p, search_path, stage2=stage2)
+            found = find_package_inner(p, search_path, stage2)
             if not found:
                 raise RuntimeError(
                     f'Package {p} requested in {name} was not found.')
             results.extend(found)
         print()
         return results
-    return find_package_inner(name, search_path, stage2=stage2)
+    return find_package_inner(name, search_path, stage2)
 
 
-def find_package_inner(name: str, search_path: str, group=False, stage2=False) -> List[ACBSPackageInfo]:
+def find_package_inner(name: str, search_path: str, stage2: bool, group=False) -> List[ACBSPackageInfo]:
     if os.path.isdir(os.path.join(search_path, name)):
         flat_path = os.path.join(search_path, name, 'autobuild')
         if os.path.isdir(flat_path):
-            return [parse_package(os.path.join(search_path, name, 'autobuild'), stage2=stage2)]
+            return [parse_package(os.path.join(search_path, name, 'autobuild'), stage2)]
         # is this a package group?
-        group_result = check_package_group(name, search_path, name, stage2=stage2)
+        group_result = check_package_group(name, search_path, name, stage2)
         if group_result:
             return group_result
     with os.scandir(search_path) as it:
@@ -91,12 +91,12 @@ def find_package_inner(name: str, search_path: str, group=False, stage2=False) -
                     full_search_path = os.path.join(
                         search_path, entry.name, entry_inner.name, 'autobuild')
                     if entry_inner.name == name and os.path.isdir(full_search_path):
-                        return [parse_package(full_search_path, stage2=stage2)]
+                        return [parse_package(full_search_path, stage2)]
                     if not group:
                         continue
                     # is this a package group?
                     group_result = check_package_group(
-                        name, search_path, os.path.join(entry.name, entry_inner.name), stage2=stage2)
+                        name, search_path, os.path.join(entry.name, entry_inner.name), stage2)
                     if group_result:
                         return group_result
     if group:
@@ -124,7 +124,7 @@ def check_package_groups(packages: List[ACBSPackageInfo]):
             groups_seen[base_slug] = pkg.group_seq
 
 
-def expand_package_group(package: ACBSPackageInfo, search_path: str, stage2=False) -> List[ACBSPackageInfo]:
+def expand_package_group(package: ACBSPackageInfo, search_path: str, stage2: bool) -> List[ACBSPackageInfo]:
     group_root = os.path.join(search_path, package.base_slug)
     original_base = package.base_slug
     actionables: List[ACBSPackageInfo] = []
@@ -138,7 +138,7 @@ def expand_package_group(package: ACBSPackageInfo, search_path: str, stage2=Fals
                 'Malformed sub-package name: {name}'.format(name=entry.name))
         try:
             sequence = int(splitted[0])
-            package = parse_package(entry.path, stage2=stage2)
+            package = parse_package(entry.path, stage2)
             if package:
                 package.base_slug = original_base
                 package.group_seq = sequence

--- a/acbs/main.py
+++ b/acbs/main.py
@@ -99,7 +99,7 @@ class BuildCore(object):
         acbs.pm.reorder_mode = self.reorder
         for n, i in enumerate(self.build_queue):
             logging.debug(f'Finding {i}...')
-            print(f'[{n + 1}/{len(self.build_queue)}] {i}\t\t\r', end='', flush=True)
+            print(f'[{n + 1}/{len(self.build_queue)}] {i:30}\r', end='', flush=True)
             package = find_package(i, self.tree_dir, stage2=self.stage2)
             if not package:
                 raise RuntimeError(f'Could not find package {i}')

--- a/acbs/main.py
+++ b/acbs/main.py
@@ -7,11 +7,11 @@ import traceback
 from pathlib import Path
 from typing import List, Tuple
 
-import acbs.ab3cfg
 import acbs.fetch
 import acbs.parser
 
 from acbs import __version__
+from acbs.ab3cfg import is_in_stage2
 from acbs.base import ACBSPackageInfo
 from acbs.checkpoint import ACBSShrinkWrap, do_shrink_wrap, checkpoint_to_group
 from acbs.const import CONF_DIR, DUMP_DIR, LOG_DIR, TMP_DIR, AUTOBUILD_CONF_DIR
@@ -39,15 +39,13 @@ class BuildCore(object):
         self.package_cursor = 0
         self.reorder = args.reorder
         self.save_list = args.save_list
-        self.stage2 = False
         # static vars
         self.autobuild_conf_dir = AUTOBUILD_CONF_DIR
         self.conf_dir = CONF_DIR
         self.dump_dir = DUMP_DIR
         self.tmp_dir = TMP_DIR
         self.log_dir = LOG_DIR
-        self.ab3 = acbs.ab3cfg.AB3Cfg(os.path.join(AUTOBUILD_CONF_DIR, 'ab3cfg.sh'))
-        self.stage2 = self.ab3.is_in_stage2()
+        self.stage2 = is_in_stage2()
         if args.acbs_tree:
             self.tree = args.acbs_tree[0]
         self.init()

--- a/acbs/main.py
+++ b/acbs/main.py
@@ -172,7 +172,7 @@ class BuildCore(object):
             if self.reorder:
                 print()
                 resolved = self.reorder_deps(
-                    [item for sublist in resolved for item in sublist])
+                    [item for sublist in resolved for item in sublist], self.stage2)
         else:
             logging.warning('Warning: Dependency resolution disabled!')
             resolved = [[package] for package in packages]

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 from acbs import bashvar
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.pm import filter_dependencies
-from acbs.utils import get_arch_name, tarball_pattern, fail_arch_regex
+from acbs.utils import get_arch_name, tarball_pattern, fail_arch_regex, get_defines_file_path
 
 generate_mode = False
 
@@ -125,9 +125,10 @@ def parse_package_url_legacy(var: Dict[str, str]) -> ACBSSourceInfo:
     return acbs_source_info
 
 
-def parse_package(location: str) -> ACBSPackageInfo:
+def parse_package(location: str, stage2=False) -> ACBSPackageInfo:
     logging.debug('Parsing {}...'.format(location))
-    defines_location = os.path.join(location, "defines")
+    # Call a helper function to check if there's a stage2 defines automatically
+    defines_location = get_defines_file_path(location, stage2)
     spec_location = os.path.join(location, '..', 'spec')
     with open(defines_location, 'rt') as f:
         var = bashvar.eval_bashvar(f.read(), filename=defines_location)

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -8,9 +8,19 @@ from typing import Dict, List, Optional
 from acbs import bashvar
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.pm import filter_dependencies
-from acbs.utils import get_arch_name, tarball_pattern, fail_arch_regex, get_defines_file_path
+from acbs.utils import get_arch_name, tarball_pattern, fail_arch_regex
 
 generate_mode = False
+
+
+def get_defines_file_path(location: str, stage2: bool=False) -> str:
+    '''
+    Return ${location}/defines or ${location}/defines.stage2 depending on the value of stage2 and whether the .stage2 file exists.
+    '''
+    if stage2 and os.path.exists(os.path.join(location, 'defines.stage2')):
+        return os.path.join(location, 'defines.stage2')
+    else:
+        return os.path.join(location, 'defines')
 
 
 def parse_url_schema(url: str, checksum: str) -> ACBSSourceInfo:

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -13,7 +13,7 @@ from acbs.utils import get_arch_name, tarball_pattern, fail_arch_regex
 generate_mode = False
 
 
-def get_defines_file_path(location: str, stage2: bool=False) -> str:
+def get_defines_file_path(location: str, stage2: bool) -> str:
     '''
     Return ${location}/defines or ${location}/defines.stage2 depending on the value of stage2 and whether the .stage2 file exists.
     '''
@@ -135,7 +135,7 @@ def parse_package_url_legacy(var: Dict[str, str]) -> ACBSSourceInfo:
     return acbs_source_info
 
 
-def parse_package(location: str, stage2=False) -> ACBSPackageInfo:
+def parse_package(location: str, stage2: bool) -> ACBSPackageInfo:
     logging.debug('Parsing {}...'.format(location))
     # Call a helper function to check if there's a stage2 defines automatically
     defines_location = get_defines_file_path(location, stage2)

--- a/acbs/resume.py
+++ b/acbs/resume.py
@@ -57,6 +57,7 @@ def do_resume_checkpoint(filename: str, args):
 
     state = do_load_checkpoint(filename)
     builder = BuildCore(args)
+    stage2 = builder.stage2
     logging.info('Resuming from {}'.format(filename))
     if state.version != __version__:
         logging.warning(
@@ -83,7 +84,7 @@ def do_resume_checkpoint(filename: str, args):
         # the spec files changed
         if index < new_cursor:
             new_cursor = index
-        resumed_packages.extend(find_package(p.name, builder.tree_dir))
+        resumed_packages.extend(find_package(p.name, builder.tree_dir, stage2))
         # index doesn't matter now, since changes have been detected
     if not check_dpkg_state(state, resumed_packages[:new_cursor]):
         name = checkpoint_to_group(

--- a/acbs/resume.py
+++ b/acbs/resume.py
@@ -97,7 +97,7 @@ def do_resume_checkpoint(filename: str, args):
     if new_cursor != (state.cursor - 1):
         logging.warning(
             'Senario mismatch detected! Dependency resolution will be re-attempted.')
-        resolved = builder.resolve_deps(resumed_packages)
+        resolved = builder.resolve_deps(resumed_packages, stage2)
         logging.info(
             'Dependencies resolved, {} packages in the queue'.format(len(resolved)))
         resume_build()

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -326,3 +326,12 @@ class ACBSLogFormatter(logging.Formatter):
                               logging.INFO, logging.DEBUG):
             record.msg = f'[{lvl_map[record.levelname]}]: \033[1m{record.msg}\033[0m'
         return super(ACBSLogFormatter, self).format(record)
+
+def get_defines_file_path(location, stage2=False) -> str:
+    '''
+    Return ${location}/defines or ${location}/defines.stage2 on various conditions.
+    '''
+    if stage2 == False:
+        return os.path.join(location, 'defines')
+    if os.path.exists(os.path.join(location, 'defines.stage2')):
+        return os.path.join(location, 'defines.stage2')

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -326,12 +326,3 @@ class ACBSLogFormatter(logging.Formatter):
                               logging.INFO, logging.DEBUG):
             record.msg = f'[{lvl_map[record.levelname]}]: \033[1m{record.msg}\033[0m'
         return super(ACBSLogFormatter, self).format(record)
-
-def get_defines_file_path(location, stage2=False) -> str:
-    '''
-    Return ${location}/defines or ${location}/defines.stage2 on various conditions.
-    '''
-    if stage2 == False:
-        return os.path.join(location, 'defines')
-    if os.path.exists(os.path.join(location, 'defines.stage2')):
-        return os.path.join(location, 'defines.stage2')

--- a/tests/test.py
+++ b/tests/test.py
@@ -32,7 +32,7 @@ def find_package_generic(name: str):
     make_build_dir_mock = unittest.mock.Mock(
         spec=make_build_dir, return_value='/tmp/')
     acbs.find.make_build_dir = make_build_dir_mock
-    return acbs.find.find_package(name, './tests/'), make_build_dir_mock
+    return acbs.find.find_package(name, './tests/', stage2=False), make_build_dir_mock
 
 
 class TestParser(unittest.TestCase):
@@ -40,7 +40,7 @@ class TestParser(unittest.TestCase):
         acbs.parser.arch = 'none'
         acbs.parser.filter_dependencies = fake_pm
         package = acbs.parser.parse_package(
-            './tests/fixtures/test-1/autobuild')
+            './tests/fixtures/test-1/autobuild', stage2=False)
         self.assertEqual(package.deps, ['test-2', 'test-3', 'test-4'])
         self.assertEqual(package.version, '1')
         self.assertEqual(package.source_uri[0].type, 'none')
@@ -49,7 +49,7 @@ class TestParser(unittest.TestCase):
         acbs.parser.arch = 'arch'
         acbs.parser.filter_dependencies = fake_pm
         package = acbs.parser.parse_package(
-            './tests/fixtures/test-1/autobuild')
+            './tests/fixtures/test-1/autobuild', stage2=False)
         self.assertEqual(package.deps, ['test-2', 'test-3', 'test-17'])
         self.assertEqual(package.version, '1')
         self.assertEqual(package.source_uri[0].type, 'none')
@@ -58,8 +58,8 @@ class TestParser(unittest.TestCase):
         acbs.parser.arch = 'arch'
         acbs.parser.filter_dependencies = fake_pm
         package = acbs.parser.parse_package(
-            './tests/fixtures/test-3/autobuild')
-        packages = tarjan_search(get_deps_graph([package]), './tests')
+            './tests/fixtures/test-3/autobuild', stage2=False)
+        packages = tarjan_search(get_deps_graph([package]), './tests', stage2=False)
         error = check_scc(packages)
         self.assertEqual(error, True)
 
@@ -98,7 +98,7 @@ class TestParser(unittest.TestCase):
         acbs.parser.arch = 'none'
         acbs.parser.filter_dependencies = fake_pm
         package = acbs.parser.parse_package(
-            './tests/fixtures/test-4/autobuild')
+            './tests/fixtures/test-4/autobuild', stage2=False)
         self.assertEqual(package.deps, ['test-4'])
         self.assertEqual(package.version, '1')
         self.assertEqual(package.source_uri[0].type, 'git')


### PR DESCRIPTION
This PR follows the introduction of Stage 2 support in Autobuild3.

Stage 2 mode aids in bootstrapping AOSC OS from a base Linux environment, with Autobuild, ACBS and a minimal set of packages available. One can simply add `ABSTAGE2=1` flag to `/etc/autobuild/ab3cfg.sh` to enable Stage 2 mode.

Stage 2 usually minimizes package dependencies, and then one can bootstrap full featured AOSC OS from it. Autobuild 3 part of the implementation is done by @MingcongBai, whereas I implemented ACBS part.