### PR TITLE
main: print build timings even if no previous build succeeded

### DIFF
--- a/acbs/main.py
+++ b/acbs/main.py
@@ -309,8 +309,7 @@ class BuildCore(object):
                 check_artifact(task.name, build_dir)
             except Exception:
                 # early printing of build summary before exploding
-                if build_timings:
-                    print_build_timings(build_timings, packages[idx:], time.monotonic() - start)
+                print_build_timings(build_timings, packages[idx:], time.monotonic() - start)
                 raise RuntimeError(
                     f'Build directory of the failed package: {build_dir}')
             build_timings.append((task_name, time.monotonic() - start))


### PR DESCRIPTION
If the first package failed to build, the build timings summary is not shown. This pull requests change the code to always show the summary.