### PR TITLE
acbs: treat /tree as a "safe directory"

### DIFF
--- a/acbs/main.py
+++ b/acbs/main.py
@@ -24,6 +24,7 @@ from acbs.utils import (
     ACBSLogFormatter,
     ACBSLogPlainFormatter,
     check_artifact,
+    detect_nspawn,
     full_line_banner,
     generate_checksums,
     guess_subdir,
@@ -39,6 +40,12 @@ from acbs.utils import (
 
 
 CIEL_LOCK_PATH = '/debs/fresh.lock'
+
+# Git config to treat the ABBS tree as "safe directory".
+GIT_CONFIG_SAFEDIR = """
+[safe]
+\tdirectory = /tree
+"""
 
 def ciel_invalidate_cache():
     logging.info('Asking ciel to refresh repository...')
@@ -148,6 +155,14 @@ class BuildCore(object):
                     raise ValueError('Tree not found!')
             else:
                 raise Exception('forest.conf not found')
+
+        # Install a git config file to allow dubious ownership in /tree.
+        if detect_nspawn():
+            try:
+                with open("/root/.gitconfig", 'w+') as f:
+                    f.writelines(GIT_CONFIG_SAFEDIR)
+            except Exception as e:
+                logging.warning("Unable to install git config file: {}, skipping.".format(e))
 
     def __install_logger(self, str_verbosity=logging.INFO,
                          file_verbosity=logging.DEBUG):

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -185,7 +185,7 @@ def generate_metadata(task: ACBSPackageInfo) -> str:
     tree_commit = 'unknown'
     try:
         tree_commit = subprocess.check_output(
-            ['git', 'describe', '--always', '--dirty'], cwd=task.script_location).decode('utf-8').strip()
+            ['git', '-c', 'safe.directory=/tree', 'describe', '--always', '--dirty'], cwd=task.script_location).decode('utf-8').strip()
     except subprocess.CalledProcessError as ex:
         logging.warning(f'Could not determine tree commit: {ex}')
     return f'X-AOSC-ACBS-Version: {__version__}\nX-AOSC-Commit: {tree_commit}\n'
@@ -195,19 +195,19 @@ def generate_version_stamp(task: ACBSPackageInfo) -> str:
     try:
         stamp = ''
         head_ref = subprocess.check_output(
-            ['git', 'symbolic-ref', 'HEAD'], cwd=task.script_location).decode('utf-8').strip()
+            ['git', '-c', 'safe.directory=/tree', 'symbolic-ref', 'HEAD'], cwd=task.script_location).decode('utf-8').strip()
         if head_ref == 'refs/heads/stable':
             logging.info(f'Using no version stamp')
             return ''
 
         dirty = len(subprocess.check_output(
-            ['git', 'status', '--porcelain'], cwd=task.script_location).decode('utf-8').strip()) != 0
+            ['git', '-c', 'safe.directory=/tree', 'status', '--porcelain'], cwd=task.script_location).decode('utf-8').strip()) != 0
         timestamp = None
         if dirty:
             timestamp = int(time.time())
         else:
             timestamp = int(subprocess.check_output(
-                ['git', 'show', '-s', '--format=%ct', 'HEAD'], cwd=task.script_location).decode('utf-8').strip())
+                ['git', '-c', 'safe.directory=/tree', 'show', '-s', '--format=%ct', 'HEAD'], cwd=task.script_location).decode('utf-8').strip())
         stamp += '~pre'
         stamp += (
             datetime.datetime.utcfromtimestamp(timestamp)
@@ -438,3 +438,16 @@ class ACBSLogPlainFormatter(logging.Formatter):
                               logging.INFO, logging.DEBUG):
             record.msg = f'[{lvl_map[record.levelname]}]: {record.msg}'
         return super(ACBSLogFormatter, self).format(record)
+
+def detect_nspawn() -> bool:
+    try:
+        with open("/run/systemd/container", "r") as f:
+            content = f.readline()
+            if content.strip() == "systemd-nspawn":
+                return True
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        logging.warning("Unable to detect containerization: {}, assuming false.".format(e))
+        return False
+    return False


### PR DESCRIPTION
- This allows maintainers to build packages with correct version numbers, if their /TREE is not owned by root (e.g. using regular user for development and SSH access).
- Without this fix, ACBS will be unable to get commit, branch and working tree status (e.g. whether if it is in stable, to add extra version strings if TREE is in a topic branch) when the ABBS tree is not owned by root.

* acbs/main: install safe.directory configuration if systemd-nspawn is detected (assuming it is a Ciel container instance).
* acbs/utils: Add parameters to treat /tree as "safe directory".