### PR TITLE
Support architecture groups

### DIFF
--- a/acbs/const.py
+++ b/acbs/const.py
@@ -14,6 +14,7 @@ ANSI_BROWN = '\033[33m'
 
 # Common paths
 CONF_DIR = '/etc/acbs/'
+AUTOBUILD_DIR = '/usr/lib/autobuild4/'
 AUTOBUILD_CONF_DIR = '/etc/autobuild/'
 DUMP_DIR = '/var/cache/acbs/tarballs/'
 TMP_DIR = '/var/cache/acbs/build/'

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -3,13 +3,13 @@ import logging
 import os
 import re
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from acbs import bashvar
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.pm import filter_dependencies
-from acbs.utils import fail_arch_regex, get_arch_name, tarball_pattern
+from acbs.utils import fail_arch_regex, get_arch_name, get_archgroups, tarball_pattern
 
 generate_mode = False
 
@@ -88,12 +88,25 @@ def parse_fetch_options(options: str, acbs_source_info: ACBSSourceInfo):
     return acbs_source_info
 
 
+def get_var_arch(context: Dict[str, str], varname) -> Union[str, None]:
+    try_names = []
+    # Try to expand VARNAME__ARCH first.
+    try_names.append('{varname}__{arch}'.format(varname=varname, arch=arch.upper()))
+    # Then try expanding VARNAME__ARCHGROUP, e.g. VARNAME__RETRO.
+    try_names.extend(['{varname}__{group}'.format(varname=varname, group=g.upper()) for g in archgroups])
+    # Then try the VARNAME itself.
+    try_names.append(varname)
+    for try_name in try_names:
+        if try_name in context.keys():
+            return context[try_name]
+
+    return None
+
+
 def parse_package_url(var: Dict[str, str], ignore_empty_srcs: bool) -> List[ACBSSourceInfo]:
     acbs_source_info: List[ACBSSourceInfo] = []
-    sources = var.get('SRCS__{arch}'.format(
-        arch=arch.upper())) or var.get('SRCS')
-    checksums = var.get('CHKSUMS__{arch}'.format(
-        arch=arch.upper())) or var.get('CHKSUMS')
+    sources = get_var_arch(var, 'SRCS')
+    checksums = get_var_arch(var, 'CHKSUMS')
     if var.get('DUMMYSRC') in ['y', 'yes', '1']:
         acbs_source_info.append(ACBSSourceInfo('none', '', ''))
         return acbs_source_info
@@ -148,23 +161,19 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
             # source info parser will fail, as there is no SRCS for current
             # arch.
             ignore_empty_srcs = True
-    deps_arch: Optional[str] = var.get('PKGDEP__{arch}'.format(
-        arch=arch.upper()))
+    deps: Optional[str] = get_var_arch(var, 'PKGDEP')
     # determine whether this is an undefined value or an empty string
-    deps: str = (var.get('PKGDEP') or '') if deps_arch is None else deps_arch
-    builddeps_arch: Optional[str] = var.get('BUILDDEP__{arch}'.format(
-        arch=arch.upper()))
-    builddeps = var.get(
-        'BUILDDEP') if builddeps_arch is None else builddeps_arch
-    deps += ' ' + (builddeps or '')  # add builddep
+    all_deps: str = '' if deps is None else deps
+    builddeps: Optional[str] = get_var_arch(var, 'BUILDDEP')
+    all_deps += ' ' + (builddeps or '')  # add builddep
     # architecture specific dependencies
     acbs_source_info = parse_package_url(spec_var, ignore_empty_srcs)
-    if not deps:
+    if not all_deps:
         result = ACBSPackageInfo(
             name=var['PKGNAME'], deps=[], location=location, source_uri=acbs_source_info)
     else:
         # filter out dependencies that are prefixed with @AB_ (autobuild special placeholders)
-        deps_iter = filter(lambda d: not d.startswith("@AB_"), deps.split())
+        deps_iter = filter(lambda d: not d.startswith("@AB_"), all_deps.split())
         result = ACBSPackageInfo(
             name=var['PKGNAME'], deps=list(deps_iter), location=location, source_uri=acbs_source_info)
     result.bin_arch = var.get('ABHOST') or arch
@@ -233,3 +242,5 @@ arch = os.environ.get('CROSS') or os.environ.get(
     'ARCH') or get_arch_name() or ''
 if not arch:
     raise ValueError('Unable to determine architecture name')
+
+archgroups = get_archgroups(arch)

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import os
 import re
@@ -7,7 +8,9 @@ import signal
 import subprocess
 import tempfile
 import time
-from typing import Dict, List, Optional, Sequence, Tuple, cast
+
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
 
 from acbs import __version__
 from acbs.ab4cfg import get_arch_override
@@ -20,6 +23,7 @@ from acbs.const import (
     ANSI_RST,
     ANSI_YELLOW,
     AUTOBUILD_CONF_DIR,
+    AUTOBUILD_DIR,
 )
 from acbs.crypto import check_hash_hashlib_inner
 
@@ -118,6 +122,34 @@ def get_arch_name() -> Optional[str]:
     return None
 
 
+def get_archgroups(arch: Union[str, None]=None) -> List[str]:
+    """
+    Get all defined architecture groups for the host machine
+
+    :param arch: When set, fetches all groups containing the specified arch
+                 instead of the host macnine.
+    :returns: List of the archgroups, such as ['mainline', '64bit'].
+
+    """
+    groups = []
+    if not arch:
+        arch = get_arch_name()
+    if not arch:
+        return groups
+
+    archgroup_path = Path(AUTOBUILD_DIR) / 'sets' / 'arch_groups.json'
+    archgroup_data: dict[str, list[str]] = {}
+    try:
+        fd = open(archgroup_path, 'r')
+        archgroup_data.update(json.load(fd))
+    except Exception as e:
+        logging.warning("Unable to read arch group data from Autobuild4: {}".format(e))
+        return groups
+
+    groups.extend([x for x in archgroup_data.keys() if arch in archgroup_data[x]])
+
+    return groups
+
 def full_line_banner(msg: str, char='-') -> str:
     """
     Print a full line banner with customizable texts
@@ -193,7 +225,7 @@ def start_build_capture(env: Dict[str, str], build_dir: str):
         f.write(footer.encode())
         if signal_status or exit_status:
             raise RuntimeError('autobuild4 did not exit successfully.')
-        
+
 def start_general_autobuild_metadata(env: Dict[str, str], script_location: str, package_name: str, build_dir: str):
     env["AB_WRITE_METADATA"] = "1"
     subprocess.check_call(['autobuild', '-p'], env=env)


### PR DESCRIPTION
This allows ACBS to read fields like `SRCS__RETRO`, `PKGDEP__RETRO` and `BUILDDEP__RETRO` without defining the names for every architecture belonging to such group.