### PR TITLE
utils: Move flags into re.compile statements

### DIFF
--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -35,8 +35,8 @@ try:
 except ImportError:
     pexpect = None
 
-chksum_pattern = re.compile(r"CHKSUM(?:S)?=['\"].*?['\"]")
-tarball_pattern = re.compile(r'\.(tar\..+|cpio\..+)')
+chksum_pattern = re.compile(r"CHKSUM(?:S)?=['\"].*?['\"]", flags=re.MULTILINE | re.DOTALL)
+tarball_pattern = re.compile(r'\.(tar\..+|cpio\..+)', flags=re.MULTILINE | re.DOTALL)
 SIGNAMES = dict((k, v) for v, k in reversed(sorted(signal.__dict__.items()))
                 if v.startswith('SIG') and not v.startswith('SIG_'))
 
@@ -419,9 +419,8 @@ def generate_checksums(info: List[ACBSSourceInfo], legacy=False) -> str:
 def write_checksums(spec: str, checksums: str):
     with open(spec, 'rt') as f:
         content = f.read()
-    if re.search(chksum_pattern, content, re.MULTILINE | re.DOTALL):
-        content = re.sub(chksum_pattern, checksums, content,
-                         flags=re.MULTILINE | re.DOTALL)
+    if re.search(chksum_pattern, content):
+        content = re.sub(chksum_pattern, checksums, content)
     else:
         content = content.rstrip() + "\n" + checksums + "\n"
     with open(spec, 'wt') as f:


### PR DESCRIPTION
`re` in Python 3.14 no longer allows setting flags with compiled statements.

Example error log:
```
[ERROR]: cannot process flags argument with a compiled pattern
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/acbs/main.py", line 213, in build
    self.build_sequential(build_timings, packages)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/acbs/main.py", line 315, in build_sequential
    write_checksums(spec_location, checksum)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/acbs/utils.py", line 422, in write_checksums
    if re.search(chksum_pattern, content, re.MULTILINE | re.DOTALL):
       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/re/__init__.py", line 177, in search
    return _compile(pattern, flags).search(string)
           ~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/re/__init__.py", line 345, in _compile
    raise ValueError(
        "cannot process flags argument with a compiled pattern")
ValueError: cannot process flags argument with a compiled pattern
[INFO]: ACBS is trying to save your build status...
[INFO]: ... saved to /tmp/1778094153.acbs-ckpt

[CRIT]: Oops! RuntimeError: Build error.
Use `acbs-build --resume /tmp/1778094153.acbs-ckpt` to resume after you sorted out the situation.
```