### PR TITLE
Afterglow fixes 20260703

### DIFF
--- a/acbs/base.py
+++ b/acbs/base.py
@@ -1,4 +1,3 @@
-import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -38,7 +37,7 @@ class ACBSPackageInfo:
     version: str = ''
     epoch: str = ''
     subdir: Optional[str] = None
-    fail_arch: Optional[re.Pattern] = None  # fail_arch regex
+    fail_arch: Optional[str] = None  # fail_arch expression
     bin_arch: str = ''
     script_location: str = field(init=False)  # script location (autobuild directory)
     exported: Dict[str, str] = field(default_factory=dict)  # extra exported variables from spec

--- a/acbs/fetch.py
+++ b/acbs/fetch.py
@@ -177,15 +177,19 @@ def blob_processor(package: ACBSPackageInfo, index: int, source_name: str) -> No
 
 def git_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
     full_path = os.path.join(source_location, name)
+    env = {'GIT_TERMINAL_PROMPT': '0'}
+    for predefined in ['http_proxy', 'https_proxy']:
+        if predefined in os.environ:
+            env[predefined] = os.environ[predefined]
     if not os.path.exists(full_path):
-        subprocess.check_call(['git', 'clone', '--bare', '--filter=blob:none', info.url, full_path], env={'GIT_TERMINAL_PROMPT': '0'})
+        subprocess.check_call(['git', 'clone', '--bare', '--filter=blob:none', info.url, full_path], env=env)
     else:
         logging.info('Updating repository...')
         # --prune: prune remote-tracking branches no longer on remote
         # --tags: fetch all tags and associated objects
         # --force: force overwrite of local reference
         subprocess.check_call(
-            ['git', 'fetch', 'origin', '+refs/heads/*:refs/heads/*', '--prune', '--tags', '--force'], cwd=full_path, env={'GIT_TERMINAL_PROMPT': '0'})
+            ['git', 'fetch', 'origin', '+refs/heads/*:refs/heads/*', '--prune', '--tags', '--force'], cwd=full_path, env=env)
     info.source_location = full_path
     return info
 

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from acbs import bashvar
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.pm import filter_dependencies
-from acbs.utils import fail_arch_regex, get_arch_name, get_archgroups, tarball_pattern
+from acbs.utils import buildable, get_arch_name, get_archgroups, tarball_pattern
 
 generate_mode = False
 
@@ -148,10 +148,8 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
         spec_var = bashvar.eval_bashvar(f.read(), filename=spec_location)
         assert isinstance(spec_var, dict)
     fail_arch = var.get('FAIL_ARCH')
-    fail_arch_re: Optional[re.Pattern] = None
     if fail_arch:
-        fail_arch_re = fail_arch_regex(fail_arch)
-        if fail_arch_re.match(arch):
+        if not buildable(arch, fail_arch):
             logging.debug(f'Package {var["PKGNAME"]} is not buildable on current arch: {arch}. '
                            'Any encountered empty SRCS will be ignored.')
             # Continue parsing but ignore any source error, since we still
@@ -181,7 +179,7 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
     result.rel = release
     version = get_var_arch(spec_var, 'VER')
     if fail_arch:
-        result.fail_arch = fail_arch_re
+        result.fail_arch = fail_arch
     if version:
         result.version = version
     subdir = get_var_arch(spec_var, 'SUBDIR')
@@ -230,7 +228,7 @@ def get_tree_by_name(filename: str, tree_name) -> str:
 
 
 def check_buildability(package: ACBSPackageInfo, required_by: Optional[str]=None) -> bool:
-    if package.fail_arch and package.fail_arch.match(arch):
+    if package.fail_arch and not buildable(arch, package.fail_arch):
         if required_by:
             raise RuntimeError(f'{package.name} is required by `{required_by}` but is not buildable on `{arch}` (FAIL_ARCH).')
         else:

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -28,6 +28,8 @@ from acbs.const import (
 from acbs.crypto import check_hash_hashlib_inner
 
 build_logging = False
+INCLUDE = 0
+EXCLUDE = 1
 
 try:
     import pexpect
@@ -429,31 +431,39 @@ def write_checksums(spec: str, checksums: str):
     return
 
 
-def fail_arch_regex(expr: str) -> re.Pattern:
-    regex = '^'
-    negated = False
-    sup_bracket = False
+def fail_arch_regex(expr: str) -> Tuple[int, re.Pattern]:
+    regex = '^('
+
     if len(expr) < 3:
         raise ValueError('Pattern too short.')
-    for i, c in enumerate(expr):
-        if i == 0 and c == '!':
-            negated = True
-            if expr[1] != '(':
-                regex += '('
-                sup_bracket = True
-            continue
-        if negated:
-            if c == '(':
-                regex += '(?!'
-                continue
-            elif i == 1 and sup_bracket:
-                regex += '?!'
-        if c == '|' or c == ')':
-            regex += '$'
-        regex += c
-    if sup_bracket:
-        regex += '$)'
-    return re.compile(regex)
+    mode = EXCLUDE
+    # Perform checks
+    if expr[0] == '!':
+        mode = EXCLUDE
+    elif expr[0] == '@':
+        mode = INCLUDE
+    elif re.search('[(|)]', expr) is not None:
+        raise Exception(f'Invalid FAIL_ARCH expression: "{expr}". Refer to bash(1) § Pattern Matching for details.')
+    else:
+        # Disallow build for one specific archgroup/target.
+        return (INCLUDE, re.compile(f'^{expr}$'))
+    regex += '|'.join(expr[1:].strip('()').split('|'))
+    regex += ')$'
+    return (mode, re.compile(regex))
+
+
+# Check if the package is buildable on current architecture.
+def buildable(arch, exp) -> bool:
+    mode, regex = fail_arch_regex(exp)
+    match_list = get_archgroups(arch)
+    match_list.append(arch)
+    for entry in match_list:
+        if regex.match(entry):
+            if mode == INCLUDE:
+                return False
+            if mode == EXCLUDE:
+                return True
+    return True if mode == INCLUDE else False
 
 
 class ACBSLogFormatter(logging.Formatter):

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -438,11 +438,11 @@ def fail_arch_regex(expr: str) -> Tuple[int, re.Pattern]:
         raise ValueError('Pattern too short.')
     mode = EXCLUDE
     # Perform checks
-    if expr[0] == '!':
+    if expr[0] == '!' and expr[1] == '(':
         mode = EXCLUDE
-    elif expr[0] == '@':
+    elif expr[0] == '@' and expr[1] == '(':
         mode = INCLUDE
-    elif re.search('[(|)]', expr) is not None:
+    elif re.search('[^0-9a-z_-]', expr) is not None or expr[1:].strip('()') == expr:
         raise Exception(f'Invalid FAIL_ARCH expression: "{expr}". Refer to bash(1) § Pattern Matching for details.')
     else:
         # Disallow build for one specific archgroup/target.

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import acbs.pm
 from acbs.const import TMP_DIR
 from acbs.deps import tarjan_search
 from acbs.parser import get_deps_graph, parse_url_schema
-from acbs.utils import fail_arch_regex, guess_extension_name, make_build_dir
+from acbs.utils import INCLUDE, EXCLUDE, fail_arch_regex, guess_extension_name, make_build_dir
 
 
 def fake_pm(package):
@@ -75,10 +75,12 @@ class TestParser(unittest.TestCase):
 
     def test_fail_arch(self):
         import re
-        self.assertEqual(re.compile("^(?!amd64$)"), fail_arch_regex("!amd64"))
-        self.assertEqual(re.compile("^amd64"), fail_arch_regex("amd64"))
-        self.assertEqual(re.compile("^(amd64$|arm64$)"), fail_arch_regex("(amd64|arm64)"))
-        self.assertEqual(re.compile("^(?!amd64$|arm64$)"), fail_arch_regex("!(amd64|arm64)"))
+        self.assertRaises(Exception, fail_arch_regex, "!amd64")
+        self.assertRaises(Exception, fail_arch_regex, "amd64|arm64")
+        self.assertRaises(Exception, fail_arch_regex, "(amd64|arm64)")
+        self.assertEqual((INCLUDE, re.compile("^amd64$")), fail_arch_regex("amd64"))
+        self.assertEqual((INCLUDE, re.compile("^(amd64|arm64)$")), fail_arch_regex("@(amd64|arm64)"))
+        self.assertEqual((EXCLUDE, re.compile("^(amd64|arm64)$")), fail_arch_regex("!(amd64|arm64)"))
 
     def test_parse_url(self):
         info = parse_url_schema('tbl::https://example.com', 'sha256::123')


### PR DESCRIPTION
- Allow `FAIL_ARCH` to match arch-groups.
- Simplify matching logic.