### PR TITLE
Modernize Python tooling and CI, with code cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.14"
         cache: 'pip' # caching pip dependencies
     - name: Install native dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python 3.14
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: "3.14"
-        cache: 'pip' # caching pip dependencies
+        
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d   # v10.0.1
+      with:
+        enable-cache: true
+          
     - name: Install native dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y libapt-pkg-dev
-        sudo snap install --classic astral-uv
     - name: Install dependencies
-      run: |
-        uv venv
-        uv pip install '.[dev]'
+      run: uv sync --locked --extra dev
     - name: Type checking using pyright
-      run: uv run --extra=dev pyright
+      run: uv run --no-sync --extra=dev pyright
     - name: Lint with Ruff
-      run: uv run --extra=dev ruff check --config 'output-format="github"'
+      run: uv run --no-sync --extra=dev ruff check --output-format=github
     - name: Run unittests
-      run: ARCH=amd64 uv run --extra=dev python -m unittest discover ./tests/
+      run: ARCH=amd64 uv run --no-sync --extra=dev python -m unittest discover ./tests/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dependencies
 ------------
 
 Mandatory:
-  - Python 3 (>= 3.6): Running the program itself.
+  - Python 3 (>= 3.14): Running the program itself.
   - GNU File (libmagic): File type detection.
   - Util-Linux: File checksum verification.
   - LibArchive (bsdtar): Archive handling.

--- a/acbs/ab4cfg.py
+++ b/acbs/ab4cfg.py
@@ -5,24 +5,22 @@ from pyparsing import ParseException
 from acbs import bashvar
 from acbs.const import AUTOBUILD_CONF_DIR
 
-from typing import Optional, Dict
 
-
-def _parse_abcfg(abcfg_path: str) -> Dict[str, str]:
+def _parse_abcfg(abcfg_path: str) -> dict[str, str]:
     with open(abcfg_path) as f:
         vars = bashvar.eval_bashvar(f.read(), filename=abcfg_path)
         assert isinstance(vars, dict)
         return vars
 
 
-def get_arch_override(abcfg_path: str) -> Optional[str]:
+def get_arch_override(abcfg_path: str) -> str | None:
     vars = _parse_abcfg(abcfg_path)
     return vars.get('ARCH')
 
 
 def is_in_stage2_file(abcfg_path: str) -> bool:
     vars = _parse_abcfg(abcfg_path)
-    stage2_val: Optional[str] = vars.get('ABSTAGE2')
+    stage2_val: str | None = vars.get('ABSTAGE2')
     return stage2_val == '1'
 
 

--- a/acbs/base.py
+++ b/acbs/base.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
 
 from acbs import __version__
 
@@ -8,14 +7,14 @@ from acbs import __version__
 class ACBSSourceInfo:
     type: str
     url: str
-    revision: Optional[str] = None
-    branch: Optional[str] = None
-    depth: Optional[int] = None
-    chksum: Tuple[str, str] = ('', '')
-    source_name: Optional[str] = ''
+    revision: str | None = None
+    branch: str | None = None
+    depth: int | None = None
+    chksum: tuple[str, str] = ('', '')
+    source_name: str | None = ''
     use_url_name: bool = False
     # where the source file/folder is located (on local filesystem)
-    source_location: Optional[str] = None
+    source_location: str | None = None
     enabled: bool = True
     # copy the repository to the build directory
     copy_repo: bool = False
@@ -26,21 +25,21 @@ class ACBSSourceInfo:
 @dataclass
 class ACBSPackageInfo:
     name: str
-    deps: List[str]
+    deps: list[str]
     location: str
-    source_uri: List[ACBSSourceInfo]
+    source_uri: list[ACBSSourceInfo]
     rel: str = '0'
-    installables: List[str] = field(default_factory=list)
+    installables: list[str] = field(default_factory=list)
     build_location: str = ''
     base_slug: str = ''  # group slug (like extra-devel/llvm), if any
     group_seq: int = 0  # group sequence number
     version: str = ''
     epoch: str = ''
-    subdir: Optional[str] = None
-    fail_arch: Optional[str] = None  # fail_arch expression
+    subdir: str | None = None
+    fail_arch: str | None = None  # fail_arch expression
     bin_arch: str = ''
     script_location: str = field(init=False)  # script location (autobuild directory)
-    exported: Dict[str, str] = field(default_factory=dict)  # extra exported variables from spec
+    exported: dict[str, str] = field(default_factory=dict)  # extra exported variables from spec
     modifiers: str = ''  # modifiers to be applied to the source file/folder (only available in autobuild4)
 
     def __post_init__(self):
@@ -54,10 +53,10 @@ class ACBSPackageInfo:
 @dataclass
 class ACBSShrinkWrap:
     cursor: int
-    timings: List[Tuple[str, float]]
-    packages: List[ACBSPackageInfo]
+    timings: list[tuple[str, float]]
+    packages: list[ACBSPackageInfo]
     no_deps: bool
     # spec states
-    sps: List[str] = field(default_factory=list)
+    sps: list[str] = field(default_factory=list)
     dpkg_state: str = ''
     version: str = __version__

--- a/acbs/bashvar.py
+++ b/acbs/bashvar.py
@@ -1,16 +1,14 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 import collections
 import logging
 import re
 import subprocess
 import tempfile
 import warnings
+from collections import OrderedDict
 
 import pyparsing as pp
 
-from typing import List, Optional, OrderedDict
+logger = logging.getLogger(__name__)
 
 pp.ParserElement.enablePackrat()
 
@@ -141,16 +139,13 @@ def combine_value(tokens, variables):
                     var = var[:-len(pattern)] + newstring
             elif exptype[0] == '#':
                 pattern = tokens.get('pattern', '')
-                if var.startswith(pattern):
-                    var = var[len(pattern):]
+                var = var.removeprefix(pattern)
             elif exptype[0] == '%':
                 pattern = tokens.get('pattern', '')
-                if var.endswith(pattern):
-                    var = var[:-len(pattern)]
+                var = var.removesuffix(pattern)
             val += var
         else:
-            warnings.warn('variable "%s" is undefined' %
-                          varname, VariableWarning)
+            warnings.warn(f'variable "{varname}" is undefined', VariableWarning)
     else:
         for tok in tokens:
             if isinstance(tok, str):
@@ -174,7 +169,7 @@ def eval_bashvar_literal(source: str):
                 variables[line['varname']] += val
             else:
                 warnings.warn(
-                    'variable "%s" is undefined' % line['varname'], VariableWarning)
+                    f'variable "{line['varname']}" is undefined', VariableWarning)
                 variables[line['varname']] = val
     return variables
 
@@ -185,9 +180,9 @@ def uniq(seq):  # Dave Kirby
     return [x for x in seq if x not in seen and not seen.add(x)]
 
 
-def eval_bashvar_ext(source: str, filename: Optional[str]=None):
+def eval_bashvar_ext(source: str, filename: str | None=None):
     # we don't specify encoding here because the env will do.
-    var: List[str] = []
+    var: list[str] = []
     stdin = []
     for ln in source.splitlines(True):
         match = re_variable.match(ln)
@@ -198,7 +193,7 @@ def eval_bashvar_ext(source: str, filename: Optional[str]=None):
     var = uniq(var)
     for v in var:
         # workaround variables containing newlines
-        stdin.append('echo "${%s//$\'\\n\'/\\\\n}"\n' % v)
+        stdin.append(f'echo "${{{v}//$\'\\n\'/\\\\n}}"\n')
     with tempfile.TemporaryDirectory() as tmpdir:
         outs, errs = subprocess.Popen(
             ('bash', '-r'), cwd=tmpdir, env={},
@@ -213,7 +208,7 @@ def eval_bashvar_ext(source: str, filename: Optional[str]=None):
     return collections.OrderedDict(zip(var, lines))
 
 
-def eval_bashvar(source: str, filename: Optional[str]=None, msg=False):
+def eval_bashvar(source: str, filename: str | None=None, msg=False):
     with warnings.catch_warnings(record=True) as wns:
         try:
             ret = eval_bashvar_literal(source)
@@ -222,10 +217,10 @@ def eval_bashvar(source: str, filename: Optional[str]=None, msg=False):
         msgs = []
         for w in wns:
             if issubclass(w.category, VariableWarning):
-                logging.debug('%s: %s', filename, w.message)
+                logger.debug('%s: %s', filename, w.message)
             elif issubclass(w.category, BashErrorWarning):
                 msgs.append(str(w.message))
-                logging.error('%s: %s', filename, w.message)
+                logger.error('%s: %s', filename, w.message)
         if msg:
             return ret, '\n'.join(msgs) if msgs else None
         else:

--- a/acbs/checkpoint.py
+++ b/acbs/checkpoint.py
@@ -4,7 +4,6 @@ import os
 import pickle
 import tarfile
 import time
-from typing import List
 
 from acbs.base import ACBSPackageInfo, ACBSShrinkWrap
 from acbs.const import DPKG_DIR
@@ -35,15 +34,15 @@ def checkpoint_dpkg() -> str:
     return hasher.hexdigest()
 
 
-def checkpoint_text(packages: List[ACBSPackageInfo]) -> str:
+def checkpoint_text(packages: list[ACBSPackageInfo]) -> str:
     return '\n'.join([package.name for package in packages])
 
 
-def checkpoint_to_group(packages: List[ACBSPackageInfo], path: str) -> str:
+def checkpoint_to_group(packages: list[ACBSPackageInfo], path: str) -> str:
     groups = os.path.join(path, 'groups')
     if not os.path.isdir(groups):
         os.makedirs(groups)
-    filename = 'acbs-{}'.format(int(time.time()))
+    filename = f'acbs-{int(time.time())}'
     with open(os.path.join(groups, filename), 'wt') as f:
         f.write(checkpoint_text(packages))
     return filename
@@ -54,7 +53,7 @@ def do_shrink_wrap(data: ACBSShrinkWrap, path: str) -> str:
     for package in data.packages:
         data.sps.append(checkpoint_spec(package))
     data.dpkg_state = checkpoint_dpkg()
-    filename = os.path.join(path, '{}.acbs-ckpt'.format(int(time.time())))
+    filename = os.path.join(path, f'{int(time.time())}.acbs-ckpt')
     with open(filename, 'wb') as f:
         pickle.dump(data, f)
     return filename

--- a/acbs/crypto.py
+++ b/acbs/crypto.py
@@ -1,15 +1,13 @@
 import hashlib
-from typing import Optional, Tuple
 
 
-def check_hash_hashlib_inner(chksum_type: str, target_file: str) -> Optional[str]:
+def check_hash_hashlib_inner(chksum_type: str, target_file: str) -> str | None:
     hash_type = chksum_type.lower()
     if hash_type == 'none':
         return None
     if hash_type not in hashlib.algorithms_available:
         raise NotImplementedError(
-            'Unsupported hash type %s! Currently supported: %s' % (
-                hash_type, ' '.join(sorted(hashlib.algorithms_available))))
+            f'Unsupported hash type {hash_type}! Currently supported: {' '.join(sorted(hashlib.algorithms_available))}')
     hash_obj = hashlib.new(hash_type)
     with open(target_file, 'rb') as f:
         for chunk in iter(lambda: f.read(4096), b''):
@@ -24,11 +22,10 @@ def hash_url(url: str) -> str:
     return hash_obj.hexdigest()
 
 
-def check_hash_hashlib(chksum_tuple: Tuple[str, str], target_file: str) -> None:
+def check_hash_hashlib(chksum_tuple: tuple[str, str], target_file: str) -> None:
     hash_type, hash_value = chksum_tuple
     hash_type = hash_type.lower()
     hash_value = hash_value.lower()
     target_hash = check_hash_hashlib_inner(hash_type, target_file)
     if hash_value != target_hash:
-        raise RuntimeError('Checksums mismatch of type %s at file %s:\nExpected: %s\nActual:   %s' % (
-            hash_type, target_file, hash_value, target_hash))
+        raise RuntimeError(f'Checksums mismatch of type {hash_type} at file {target_file}:\nExpected: {hash_value}\nActual:   {target_hash}')

--- a/acbs/deps.py
+++ b/acbs/deps.py
@@ -1,24 +1,23 @@
 from collections import OrderedDict, defaultdict, deque
-from typing import Deque, Dict, List
 
 from acbs.find import find_package
 from acbs.parser import ACBSPackageInfo
 
 # package information cache
-pool: Dict[str, ACBSPackageInfo] = {}
+pool: dict[str, ACBSPackageInfo] = {}
 
 
-def tarjan_search(packages: 'OrderedDict[str, ACBSPackageInfo]', search_path: str, stage2: bool) -> List[List[ACBSPackageInfo]]:
+def tarjan_search(packages: OrderedDict[str, ACBSPackageInfo], search_path: str, stage2: bool) -> list[list[ACBSPackageInfo]]:
     """This function describes a Tarjan's strongly connected components algorithm.
     The resulting list of ACBSPackageInfo are sorted topologically as a byproduct of the algorithm
     """
     # Initialize state trackers
-    lowlink: Dict[str, int] = defaultdict(lambda: -1)
-    index: Dict[str, int] = defaultdict(lambda: -1)
-    stackstate: Dict[str, bool] = defaultdict(bool)
-    stack: Deque[str] = deque()
-    results: List[List[ACBSPackageInfo]] = []
-    packages_list: List[str] = [i for i in packages]
+    lowlink: dict[str, int] = defaultdict(lambda: -1)
+    index: dict[str, int] = defaultdict(lambda: -1)
+    stackstate: dict[str, bool] = defaultdict(bool)
+    stack: deque[str] = deque()
+    results: list[list[ACBSPackageInfo]] = []
+    packages_list: list[str] = [i for i in packages]
     pool.update(packages)
     for i in packages_list:
         if index[i] == -1:  # recurse on each package that is not yet visited
@@ -27,7 +26,7 @@ def tarjan_search(packages: 'OrderedDict[str, ACBSPackageInfo]', search_path: st
     return results
 
 
-def prepare_for_reorder(package: ACBSPackageInfo, packages_list: List[str]) -> ACBSPackageInfo:
+def prepare_for_reorder(package: ACBSPackageInfo, packages_list: list[str]) -> ACBSPackageInfo:
     """This function prepares the package for reordering.
     The idea is to move the installable dependencies which are in the build list to the "uninstallable" list.
     """
@@ -46,7 +45,7 @@ def prepare_for_reorder(package: ACBSPackageInfo, packages_list: List[str]) -> A
     return package
 
 
-def strongly_connected(search_path: str, packages_list: List[str], results: list, packages: 'OrderedDict[str, ACBSPackageInfo]', vert: str, lowlink: Dict[str, int], index: Dict[str, int], stackstate: Dict[str, bool], stack: Deque[str], stage2: bool, depth=0):
+def strongly_connected(search_path: str, packages_list: list[str], results: list, packages: OrderedDict[str, ACBSPackageInfo], vert: str, lowlink: dict[str, int], index: dict[str, int], stackstate: dict[str, bool], stack: deque[str], stage2: bool, depth=0):
     # update depth indices
     index[vert] = depth
     lowlink[vert] = depth

--- a/acbs/fetch.py
+++ b/acbs/fetch.py
@@ -1,10 +1,9 @@
+import json
 import logging
 import os
 import shutil
 import subprocess
-import json
-
-from typing import Callable, Dict, List, Optional, Tuple
+from collections.abc import Callable
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -13,22 +12,22 @@ from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.crypto import check_hash_hashlib, hash_url
 from acbs.utils import guess_extension_name
 
+logger = logging.getLogger(__name__)
+
 fetcher_signature = Callable[[ACBSSourceInfo,
-                              str, str], Optional[ACBSSourceInfo]]
+                              str, str], ACBSSourceInfo | None]
 processor_signature = Callable[[ACBSPackageInfo, int, str], None]
-pair_signature = Tuple[fetcher_signature, processor_signature]
+pair_signature = tuple[fetcher_signature, processor_signature]
 generate_mode = False
 
 
-def fetch_source(info: List[ACBSSourceInfo], source_location: str, package_name: str) -> Optional[ACBSSourceInfo]:
-    logging.info('Fetching required source files...')
-    count = 0
-    for i in info:
-        count += 1
-        logging.info(f'Fetching source ({count}/{len(info)})...')
+def fetch_source(info: list[ACBSSourceInfo], source_location: str, package_name: str) -> ACBSSourceInfo | None:
+    logger.info('Fetching required source files...')
+    for count, i in enumerate(info, 1):
+        logger.info(f'Fetching source ({count}/{len(info)})...')
         # in generate mode, we need to fetch all the sources
         if not i.enabled and not generate_mode:
-            logging.info(f'Source {count} skipped.')
+            logger.info(f'Source {count} skipped.')
         # special handling for PyPI type
         url = i.url if i.type != "pypi" else f"pypi://{i.url}/{i.revision}"
         url_hash = hash_url(url)
@@ -36,52 +35,44 @@ def fetch_source(info: List[ACBSSourceInfo], source_location: str, package_name:
     return None
 
 
-def fetch_source_inner(info: ACBSSourceInfo, source_location: str, package_name: str) -> Optional[ACBSSourceInfo]:
+def fetch_source_inner(info: ACBSSourceInfo, source_location: str, package_name: str) -> ACBSSourceInfo | None:
     type_ = info.type
     retry = 0
-    fetcher: Optional[pair_signature] = handlers.get(type_.upper())
+    fetcher: pair_signature | None = handlers.get(type_.upper())
     if not fetcher or not callable(fetcher[0]):
         raise NotImplementedError(f'Unsupported source type: {type_}')
     while retry < 5:
         retry += 1
         try:
             return fetcher[0](info, source_location, package_name)
-        except Exception as ex:
-            logging.exception(ex)
-            logging.warning(f'Retrying ({retry}/5)...')
+        except Exception:
+            logger.exception("build error")
+            logger.warning(f'Retrying ({retry}/5)...')
             continue
     raise RuntimeError(
         'Unable to fetch source files, failed 5 times in a row.')
 
 
 def process_source(info: ACBSPackageInfo, source_name: str) -> None:
-    idx = 0
-    for source_uri in info.source_uri:
+    for idx, source_uri in enumerate(info.source_uri):
         type_ = source_uri.type
-        fetcher: Optional[pair_signature] = handlers.get(type_.upper())
+        fetcher: pair_signature | None = handlers.get(type_.upper())
         if not fetcher or not callable(fetcher[1]):
             raise NotImplementedError(
                 f'Unsupported source type: {type_}')
         fetcher[1](info, idx, source_name)
-        idx += 1
-    return
 
 
 # Fetchers implementations
-def tarball_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def tarball_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     if source_location:
         filename = hash_url(info.url)
         if not info.chksum[1] and not generate_mode:
             raise ValueError('No checksum found. Please specify the checksum!')
         full_path = os.path.join(source_location, filename)
-        try:
-            wget_download(info.url, full_path)
-            info.source_location = full_path
-            return info
-        except Exception:
-            raise AssertionError('Failed to fetch source with Wget!')
-        return None
-    return None
+        wget_download(info.url, full_path)
+        info.source_location = full_path
+        return info
 
 
 def wget_download(url: str, full_path: str):
@@ -102,15 +93,14 @@ def wget_download(url: str, full_path: str):
         subprocess.check_call(
             ['wget', '--connect-timeout=20', '-c', url, '-O', full_path])
         os.unlink(flag_path)  # delete the flag
-        return
-    except Exception:
-        raise AssertionError('Failed to fetch source with Wget!')
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError('Failed to fetch source with Wget!') from exc
 
 def tarball_processor_innner(package: ACBSPackageInfo, index: int, source_name: str, decompress=True) -> None:
     info = package.source_uri[index]
     if not info.source_location:
         raise ValueError('Where is the source file?')
-    logging.info('Computing %s checksum for %s...' % (info.chksum, info.source_location))
+    logger.info('Computing %s checksum for %s...', info.chksum, info.source_location)
     check_hash_hashlib(info.chksum, info.source_location)
 
     server_filename = os.path.basename(info.url)
@@ -124,13 +114,13 @@ def tarball_processor_innner(package: ACBSPackageInfo, index: int, source_name: 
     # the name will be, e.g. 'acbs-0.1.0.tar.gz'
     facade_name = info.source_name or '{name}-{version}{index}{extension}'.format(
         name=source_name, version=package.version, extension=extension,
-        index=('' if index == 0 else ('-%s' % index)))
+        index=('' if index == 0 else f'-{index}'))
     os.symlink(info.source_location, os.path.join(
         package.build_location, facade_name))
     if not decompress:
         return
     # decompress
-    logging.info(f'Extracting {facade_name}...')
+    logger.info(f'Extracting {facade_name}...')
     subprocess.check_call(['bsdtar', '--no-xattrs', '-xf', facade_name],
                           cwd=package.build_location)
     return
@@ -140,15 +130,15 @@ def tarball_processor(package: ACBSPackageInfo, index: int, source_name: str) ->
     return tarball_processor_innner(package, index, source_name)
 
 
-def pypi_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def pypi_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     # https://warehouse.pypa.io/api-reference/json.html#release
     api = f"https://pypi.org/pypi/{info.url}/{info.revision}/json"
-    logging.info("Querying PyPI API endpoint for source URL...")
+    logger.info("Querying PyPI API endpoint for source URL...")
     try:
         with urlopen(api, timeout=20) as response:
             result = json.load(response)
     except HTTPError as exc:
-        logging.error(f"Got response {exc.code}")
+        logger.error(f"Got response {exc.code}")
         raise RuntimeError("Failed to query PyPI API endpoint") from exc
 
     actual_url = ""
@@ -158,24 +148,20 @@ def pypi_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optiona
             break
     if actual_url == "":
         raise RuntimeError("Can't find source URL")
-    logging.info(f"Source URL is {actual_url}")
+    logger.info(f"Source URL is {actual_url}")
 
     ext = guess_extension_name(actual_url)
     full_path = os.path.join(source_location, name + ext)
-    try:
-        wget_download(actual_url, full_path)
-        info.source_location = full_path
-        return info
-    except Exception:
-        raise AssertionError('Failed to fetch source with Wget!')
-    return None
+    wget_download(actual_url, full_path)
+    info.source_location = full_path
+    return info
 
 
 def blob_processor(package: ACBSPackageInfo, index: int, source_name: str) -> None:
     return tarball_processor_innner(package, index, source_name, False)
 
 
-def git_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def git_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     full_path = os.path.join(source_location, name)
     env = {'GIT_TERMINAL_PROMPT': '0'}
     for predefined in ['http_proxy', 'https_proxy']:
@@ -184,7 +170,7 @@ def git_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional
     if not os.path.exists(full_path):
         subprocess.check_call(['git', 'clone', '--bare', '--filter=blob:none', info.url, full_path], env=env)
     else:
-        logging.info('Updating repository...')
+        logger.info('Updating repository...')
         # --prune: prune remote-tracking branches no longer on remote
         # --tags: fetch all tags and associated objects
         # --force: force overwrite of local reference
@@ -203,12 +189,12 @@ def git_processor(package: ACBSPackageInfo, index: int, source_name: str) -> Non
         raise ValueError('Where is the git repository?')
     checkout_location = os.path.join(package.build_location, info.source_name or source_name)
     os.mkdir(checkout_location)
-    logging.info(f'Checking out git repository at {info.revision}')
+    logger.info(f'Checking out git repository at {info.revision}')
     subprocess.check_call(
         ['git', '--git-dir', info.source_location, '--work-tree', checkout_location,
          'checkout', '-f', info.revision or ''])
     if info.submodule > 0:
-        logging.info('Fetching submodules (if any)...')
+        logger.info('Fetching submodules (if any)...')
         params = [
                 'git', '--git-dir', info.source_location, '--work-tree', checkout_location,
                 'submodule', 'update', '--init', '--filter=blob:none'
@@ -217,7 +203,7 @@ def git_processor(package: ACBSPackageInfo, index: int, source_name: str) -> Non
             params.append('--recursive')
         subprocess.check_call(params, cwd=checkout_location)
     if info.copy_repo:
-        logging.info('Copying git folder...')
+        logger.info('Copying git folder...')
         shutil.copytree(info.source_location, os.path.join(checkout_location, '.git'))
         with open(os.path.join(checkout_location, '.git', 'config'), 'r+') as f:
             content = f.read()
@@ -225,19 +211,18 @@ def git_processor(package: ACBSPackageInfo, index: int, source_name: str) -> Non
             f.seek(0)
             f.write(content)
             f.truncate()
-        return None
+        return
     with open(os.path.join(package.build_location, '.acbs-script'), 'wt') as f:
         f.write(
-            'ACBS_SRC=\'%s\';acbs_copy_git(){ abinfo \'Copying git folder...\'; cp -ar "${ACBS_SRC}" .git/; sed -i \'s|bare = true|bare = false|\' \'.git/config\'; }' % (info.source_location))
-    return None
+            f'ACBS_SRC=\'{info.source_location}\';acbs_copy_git(){{ abinfo \'Copying git folder...\'; cp -ar "${{ACBS_SRC}}" .git/; sed -i \'s|bare = true|bare = false|\' \'.git/config\'; }}')
 
 
-def svn_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def svn_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     full_path = os.path.join(source_location, name)
     if not info.revision:
         raise ValueError(
             'Please specify a svn revision for this package. (SVNCO not defined)')
-    logging.info(
+    logger.info(
         f'Checking out subversion repository at r{info.revision}')
     if not os.path.exists(full_path):
         subprocess.check_call(
@@ -254,17 +239,16 @@ def svn_processor(package: ACBSPackageInfo, index: int, source_name: str) -> Non
     if not info.source_location:
         raise ValueError('Where is the subversion repository?')
     checkout_location = os.path.join(package.build_location, info.source_name or source_name)
-    logging.info('Copying subversion repository...')
+    logger.info('Copying subversion repository...')
     shutil.copytree(info.source_location, checkout_location)
-    return
 
 
-def hg_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def hg_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     full_path = os.path.join(source_location, name)
     if not os.path.exists(full_path):
         subprocess.check_call(['hg', 'clone', '-U', info.url, full_path])
     else:
-        logging.info('Updating repository...')
+        logger.info('Updating repository...')
         subprocess.check_call(['hg', 'pull'], cwd=full_path)
     info.source_location = full_path
     return info
@@ -278,20 +262,19 @@ def hg_processor(package: ACBSPackageInfo, index: int, source_name: str) -> None
     if not info.source_location:
         raise ValueError('Where is the hg repository?')
     checkout_location = os.path.join(package.build_location, info.source_name or source_name)
-    logging.info('Copying hg repository...')
+    logger.info('Copying hg repository...')
     shutil.copytree(info.source_location, checkout_location)
-    logging.info(f'Checking out hg repository at {info.revision}')
+    logger.info(f'Checking out hg repository at {info.revision}')
     subprocess.check_call(
         ['hg', 'update', '-C', '-r', info.revision, '-R', checkout_location])
     if info.copy_repo:
-        logging.info('Copying hg repository ...')
+        logger.info('Copying hg repository ...')
         shutil.copytree(info.source_location, os.path.join(checkout_location, '.hg'))
-    return None
 
 
-def dummy_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def dummy_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     if source_location:
-        logging.info('Not fetching any source as requested')
+        logger.info('Not fetching any source as requested')
         return info
     return None
 
@@ -300,12 +283,12 @@ def dummy_processor(package: ACBSPackageInfo, index: int, source_name: str) -> N
     return None
 
 
-def bzr_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def bzr_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     full_path = os.path.join(source_location, name)
     if not os.path.exists(full_path):
         subprocess.check_call(['bzr', 'branch', '--no-tree', info.url, full_path])
     else:
-        logging.info('Updating repository...')
+        logger.info('Updating repository...')
         subprocess.check_call(['bzr', 'pull'], cwd=full_path)
     info.source_location = full_path
     return info
@@ -319,20 +302,19 @@ def bzr_processor(package: ACBSPackageInfo, index: int, source_name: str) -> Non
     if not info.source_location:
         raise ValueError('Where is the bzr repository?')
     checkout_location = os.path.join(package.build_location, info.source_name or source_name)
-    logging.info('Copying bzr repository...')
+    logger.info('Copying bzr repository...')
     shutil.copytree(info.source_location, checkout_location)
-    logging.info(f'Checking out bzr repository at {info.revision}')
+    logger.info(f'Checking out bzr repository at {info.revision}')
     subprocess.check_call(
         ['bzr', 'co', '-r', info.revision], cwd=checkout_location)
-    return None
 
 
-def fossil_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> Optional[ACBSSourceInfo]:
+def fossil_fetch(info: ACBSSourceInfo, source_location: str, name: str) -> ACBSSourceInfo | None:
     full_path = os.path.join(source_location, name + '.fossil')
     if not os.path.exists(full_path):
         subprocess.check_call(['fossil', 'clone', info.url, full_path])
     else:
-        logging.info('Updating repository...')
+        logger.info('Updating repository...')
         subprocess.check_call(['fossil', 'pull', '-R', full_path])
     info.source_location = full_path
     return info
@@ -347,15 +329,14 @@ def fossil_processor(package: ACBSPackageInfo, index: int, source_name: str) -> 
         raise ValueError('Where is the fossil repository?')
     checkout_location = os.path.join(package.build_location, info.source_name or source_name)
     os.mkdir(checkout_location)
-    logging.info('Opening up the fossil repository...')
+    logger.info('Opening up the fossil repository...')
     subprocess.check_call(
         ['fossil', 'open', info.source_location], cwd=checkout_location)
-    logging.info(f'Checking out fossil repository at {info.revision}')
+    logger.info(f'Checking out fossil repository at {info.revision}')
     subprocess.check_call(['fossil', 'update', info.revision], cwd=checkout_location)
-    return None
 
 
-handlers: Dict[str, pair_signature] = {
+handlers: dict[str, pair_signature] = {
     'GIT': (git_fetch, git_processor),
     'SVN': (svn_fetch, svn_processor),
     'BZR': (bzr_fetch, bzr_processor),

--- a/acbs/find.py
+++ b/acbs/find.py
@@ -1,13 +1,13 @@
 import logging
 import os
-from typing import Dict, List, Optional
 
 from acbs.const import TMP_DIR
-from acbs.parser import ACBSPackageInfo, ACBSSourceInfo, parse_package, check_buildability
+from acbs.parser import ACBSPackageInfo, ACBSSourceInfo, check_buildability, parse_package
 from acbs.utils import make_build_dir
 
+logger = logging.getLogger(__name__)
 
-def check_package_group(name: str, search_path: str, entry_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> Optional[List[ACBSPackageInfo]]:
+def check_package_group(name: str, search_path: str, entry_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> list[ACBSPackageInfo] | None:
     # is this a package group?
     if os.path.basename(entry_path) == os.path.basename(name) and os.path.isfile(os.path.join(search_path, entry_path, 'spec')):
         stub = ACBSPackageInfo(name, [], '', [ACBSSourceInfo('none', '', '')])
@@ -33,8 +33,7 @@ def check_package_group(name: str, search_path: str, entry_path: str, modifiers:
                     group_seq = int(
                         package_alias.split('-')[0])
                 except (ValueError, IndexError) as ex:
-                    raise ValueError('Invalid package alias: {alias}'.format(
-                        alias=package_alias)) from ex
+                    raise ValueError(f'Invalid package alias: {package_alias}') from ex
                 group_root = os.path.realpath(
                     os.path.join(full_search_path, '..'))
                 group_category = os.path.realpath(
@@ -48,7 +47,7 @@ def check_package_group(name: str, search_path: str, entry_path: str, modifiers:
     return None
 
 
-def filter_unbuildable_packages(packages: List[ACBSPackageInfo], group_name: Optional[str]=None) -> List[ACBSPackageInfo]:
+def filter_unbuildable_packages(packages: list[ACBSPackageInfo], group_name: str | None=None) -> list[ACBSPackageInfo]:
     """Filter out packages that are not buildable."""
     filtered_packages = []
     unbuildable = []
@@ -58,7 +57,7 @@ def filter_unbuildable_packages(packages: List[ACBSPackageInfo], group_name: Opt
         else:
             unbuildable.append(package.name)
     if unbuildable:
-        logging.warning(
+        logger.warning(
             "The following packages %swill be skipped as they are not buildable:\n\t%s",
             f"(in {group_name}) " if group_name else "",
             " ".join(unbuildable),
@@ -66,7 +65,7 @@ def filter_unbuildable_packages(packages: List[ACBSPackageInfo], group_name: Opt
     return filtered_packages
 
 
-def find_package(name: str, search_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> List[ACBSPackageInfo]:
+def find_package(name: str, search_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> list[ACBSPackageInfo]:
     if os.path.isfile(os.path.join(search_path, name)):
         with open(os.path.join(search_path, name), 'rt') as f:
             content = f.read()
@@ -88,7 +87,7 @@ def find_package(name: str, search_path: str, modifiers: str, tmp_dir: str = TMP
     return find_package_inner(name, search_path, modifiers=modifiers, tmp_dir=tmp_dir)
 
 
-def find_package_inner(name: str, search_path: str, group=False, modifiers: str='', tmp_dir: str = TMP_DIR) -> List[ACBSPackageInfo]:
+def find_package_inner(name: str, search_path: str, group=False, modifiers: str='', tmp_dir: str = TMP_DIR) -> list[ACBSPackageInfo]:
     if os.path.isdir(os.path.join(search_path, name)):
         flat_path = os.path.join(search_path, name, 'autobuild')
         if os.path.isdir(flat_path):
@@ -126,31 +125,30 @@ def find_package_inner(name: str, search_path: str, group=False, modifiers: str=
         return find_package_inner(name, search_path, True, modifiers, tmp_dir)
 
 
-def check_package_groups(packages: List[ACBSPackageInfo]):
+def check_package_groups(packages: list[ACBSPackageInfo]):
     """In AOSC OS build rules, the package group need to be built sequentially together.
     This function will check if the package inside the group will be built sequentially
     """
-    groups_seen: Dict[str, int] = {}
+    groups_seen: dict[str, int] = {}
     for pkg in packages:
         base_slug = pkg.base_slug
         if not base_slug:
             continue
         if base_slug in groups_seen:
             if groups_seen[base_slug] > pkg.group_seq:
-                logging.error('Package {} (in {}) has a different sequential order (#{}) after dependency resolution (should be #{})'.format(
-                    pkg.name, base_slug, pkg.group_seq, groups_seen[base_slug] + 1))
-                logging.error('This might indicate a dependency cycle between the sub-packages (needs bootstrapping?) ...')
-                logging.error('... or maybe the sub-package should be named {:02d}-{}'.format(groups_seen[base_slug] + 1, pkg.name))
-                logging.error('Please check which situation this package is in and fix it.')
+                logger.error(f'Package {pkg.name} (in {base_slug}) has a different sequential order (#{pkg.group_seq}) after dependency resolution (should be #{groups_seen[base_slug] + 1})')
+                logger.error('This might indicate a dependency cycle between the sub-packages (needs bootstrapping?) ...')
+                logger.error(f'... or maybe the sub-package should be named {groups_seen[base_slug] + 1:02d}-{pkg.name}')
+                logger.error('Please check which situation this package is in and fix it.')
                 raise ValueError('Specified sub-package order contradicts with the dependency resolution results')
         else:
             groups_seen[base_slug] = pkg.group_seq
 
 
-def expand_package_group(package: ACBSPackageInfo, search_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> List[ACBSPackageInfo]:
+def expand_package_group(package: ACBSPackageInfo, search_path: str, modifiers: str, tmp_dir: str = TMP_DIR) -> list[ACBSPackageInfo]:
     group_root = os.path.join(search_path, package.base_slug)
     original_base = package.base_slug
-    actionables: List[ACBSPackageInfo] = []
+    actionables: list[ACBSPackageInfo] = []
     for entry in os.scandir(group_root):
         if not entry.is_dir():
             continue
@@ -158,7 +156,7 @@ def expand_package_group(package: ACBSPackageInfo, search_path: str, modifiers: 
         splitted = name.split('-', 1)
         if len(splitted) != 2:
             raise ValueError(
-                'Malformed sub-package name: {name}'.format(name=entry.name))
+                f'Malformed sub-package name: {entry.name}')
         try:
             sequence = int(splitted[0])
             package = parse_package(entry.path, modifiers)
@@ -168,7 +166,7 @@ def expand_package_group(package: ACBSPackageInfo, search_path: str, modifiers: 
                 actionables.append(package)
         except ValueError as ex:
             raise ValueError(
-                'Malformed sub-package name: {name}'.format(name=entry.name)) from ex
+                f'Malformed sub-package name: {entry.name}') from ex
     # because the directory order is arbitrary, we need to sort them
     actionables = sorted(actionables, key=lambda a: a.group_seq)
     # pre-assign build location for sub-packages

--- a/acbs/magic.py
+++ b/acbs/magic.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """
 Fake magic bindings
@@ -34,16 +33,14 @@ MAGIC_NO_CHECK_ENCODING = NO_CHECK_ENCODING = 2097152
 MAGIC_NO_CHECK_BUILTIN = NO_CHECK_BUILTIN = 4173824
 
 
-class fakeMagic(object):
+class fakeMagic:
 
     def __init__(self):
         self.flags = 0
         self.cmd_args = []
-        return
 
     def magic_open(self, flags=0) -> None:
         self.flags = flags
-        return
 
     def add_cmds(self) -> None:
         self.cmd_args = ['file', '-b']

--- a/acbs/main.py
+++ b/acbs/main.py
@@ -1,12 +1,11 @@
+import fcntl
 import logging
 import logging.handlers
 import os
 import sys
 import time
 import traceback
-import fcntl
 from pathlib import Path
-from typing import List, Tuple
 
 import acbs.fetch
 import acbs.parser
@@ -19,7 +18,7 @@ from acbs.deps import prepare_for_reorder, tarjan_search
 from acbs.fetch import fetch_source, process_source
 from acbs.find import check_package_groups, find_package
 from acbs.parser import check_buildability, get_deps_graph, get_tree_by_name
-from acbs.pm import install_from_repo, enable_reorder_mode
+from acbs.pm import enable_reorder_mode, install_from_repo
 from acbs.utils import (
     ACBSLogFormatter,
     ACBSLogPlainFormatter,
@@ -37,11 +36,12 @@ from acbs.utils import (
     write_checksums,
 )
 
+logger = logging.getLogger(__name__)
 
 CIEL_LOCK_PATH = '/debs/fresh.lock'
 
 def ciel_invalidate_cache():
-    logging.info('Asking ciel to refresh repository...')
+    logger.info('Asking ciel to refresh repository...')
     if os.path.exists(CIEL_LOCK_PATH):
         with open(CIEL_LOCK_PATH, 'r+') as lock_file:
             lock_file_fd = lock_file.fileno()
@@ -52,11 +52,11 @@ def ciel_invalidate_cache():
                 lock_file.write('0')
             fcntl.flock(lock_file_fd, fcntl.LOCK_UN)
     else:
-        logging.warning('Ciel did not create lock file, skipping...')
+        logger.warning('Ciel did not create lock file, skipping...')
 
 
 def ciel_wait_for_refresh():
-    logging.info('Waiting for ciel to refresh repository...')
+    logger.info('Waiting for ciel to refresh repository...')
     if os.path.exists(CIEL_LOCK_PATH):
         with open(CIEL_LOCK_PATH, 'r') as lock_file:
             lock_file_fd = lock_file.fileno()
@@ -78,14 +78,14 @@ def ciel_wait_for_refresh():
             fcntl.flock(lock_file_fd, fcntl.LOCK_UN)
 
             if success:
-                logging.info('Ciel finished refreshing repository...')
+                logger.info('Ciel finished refreshing repository...')
             else:
-                logging.warning('Ciel failed to refresh repository in time...')
+                logger.warning('Ciel failed to refresh repository in time...')
     else:
-        logging.warning('Ciel did not create lock file, skipping...')
+        logger.warning('Ciel did not create lock file, skipping...')
 
 
-class BuildCore(object):
+class BuildCore:
 
     def __init__(self, args) -> None:
         self.debug = args.debug
@@ -134,10 +134,9 @@ class BuildCore(object):
         try:
             for directory in [self.dump_dir, self.tmp_dir, self.conf_dir,
                               self.log_dir]:
-                if not os.path.isdir(directory):
-                    os.makedirs(directory)
-        except Exception:
-            raise IOError('\033[93mFailed to create work directories\033[0m!')
+                os.makedirs(directory, exist_ok=True)
+        except OSError as exc:
+            raise OSError('\033[93mFailed to create work directories\033[0m!') from exc
         self.__install_logger(log_verbosity)
         if self.tree_dir == '':
             # If the user did not specify tree path via -b/--tree-dir, read from config
@@ -147,7 +146,7 @@ class BuildCore(object):
                 if not self.tree_dir:
                     raise ValueError('Tree not found!')
             else:
-                raise Exception('forest.conf not found')
+                raise ValueError('forest.conf not found')
 
     def __install_logger(self, str_verbosity=logging.INFO,
                          file_verbosity=logging.DEBUG):
@@ -167,7 +166,7 @@ class BuildCore(object):
             '%(asctime)s:%(levelname)s:%(message)s'))
         logger.addHandler(log_file_handler)
 
-    def strip_modifiers(self, p: str) -> Tuple[str, str]:
+    def strip_modifiers(self, p: str) -> tuple[str, str]:
         if ':' in p:
             results = p.split(':', 1)
             if len(results) == 2:
@@ -177,19 +176,19 @@ class BuildCore(object):
 
     def build(self) -> None:
         packages = []
-        build_timings: List[Tuple[str, float]] = []
+        build_timings: list[tuple[str, float]] = []
         acbs.fetch.generate_mode = self.generate
         acbs.parser.generate_mode = self.generate
         if self.stage2:
-            logging.info("Life-cycle: currently running in stage2 mode.")
+            logger.info("Life-cycle: currently running in stage2 mode.")
         # begin finding and resolving dependencies
-        logging.info('Searching and resolving dependencies...')
+        logger.info('Searching and resolving dependencies...')
         enable_reorder_mode(self.reorder)
         for n, i in enumerate(self.build_queue):
             i, modifiers = self.strip_modifiers(i)
             if not validate_package_name(i):
                 raise ValueError(f'Invalid package name: `{i}`')
-            logging.debug(f'Finding {i}...')
+            logger.debug(f'Finding {i}...')
             print(f'[{n + 1}/{len(self.build_queue)}] {i:30}\r', end='', flush=True)
             package = find_package(i, self.tree_dir, modifiers, self.tmp_dir)
             if not package:
@@ -197,46 +196,46 @@ class BuildCore(object):
             packages.extend(package)
         self.resolve_deps(packages, self.stage2)
         if not packages:
-            logging.info('Nothing to do after dependency resolution')
+            logger.info('Nothing to do after dependency resolution')
             return
-        logging.info(
+        logger.info(
             f'Dependencies resolved, {len(packages)} packages in the queue')
-        logging.debug(f'Queue: {packages}')
-        logging.info(
+        logger.debug(f'Queue: {packages}')
+        logger.info(
             f'Packages to be built: {print_package_names(packages, 5)}')
         if self.save_list:
             filename = checkpoint_to_group(packages, self.tree_dir)
-            logging.info(
+            logger.info(
                 f'ACBS has saved your build queue to groups/{filename}')
             return
         try:
             self.build_sequential(build_timings, packages)
-        except Exception as ex:
-            logging.exception(ex)
+        except Exception:
+            logger.exception("Build Failed")
             self.save_checkpoint(build_timings, packages)
         print_build_timings(build_timings, [])
 
     def save_checkpoint(self, build_timings, packages):
-        logging.info('ACBS is trying to save your build status...')
+        logger.info('ACBS is trying to save your build status...')
         shrink_wrap = ACBSShrinkWrap(
             self.package_cursor, build_timings, packages, self.no_deps)
         filename = do_shrink_wrap(shrink_wrap, '/tmp')
-        logging.info(f'... saved to {filename}')
+        logger.info(f'... saved to {filename}')
         raise RuntimeError(
             f'Build error.\nUse `acbs-build --resume {filename}` to resume after you sorted out the situation.')
 
     def reorder_deps(self, packages, stage2: bool):
-        logging.info('Re-ordering packages...')
+        logger.info('Re-ordering packages...')
         new_packages = []
         package_names = [p.name for p in packages]
         for pkg in packages:
             # prepare for re-order if necessary
-            logging.debug(f'Prepare for re-ordering: {pkg.name}')
+            logger.debug(f'Prepare for re-ordering: {pkg.name}')
             new_packages.append(prepare_for_reorder(pkg, package_names))
         graph = get_deps_graph(new_packages)
         return tarjan_search(graph, self.tree_dir, stage2)
 
-    def filter_unbuildable(self, packages: List[ACBSPackageInfo]) -> List[ACBSPackageInfo]:
+    def filter_unbuildable(self, packages: list[ACBSPackageInfo]) -> list[ACBSPackageInfo]:
         unbuildable = []
         buildable = []
         for p in packages:
@@ -245,19 +244,19 @@ class BuildCore(object):
             else:
                 buildable.append(p)
         if unbuildable:
-            logging.warning(f'The following packages will be skipped as they are not buildable:\n\t{(" ".join(unbuildable))}')
+            logger.warning(f'The following packages will be skipped as they are not buildable:\n\t{(" ".join(unbuildable))}')
         return buildable
 
     def resolve_deps(self, packages, stage2: bool):
         error = False
         if not self.no_deps:
-            logging.debug('Filtering packages...')
+            logger.debug('Filtering packages...')
             filtered = self.filter_unbuildable(packages)
             packages.clear()
             packages.extend(filtered)
-            logging.debug('Converting queue into adjacency graph...')
+            logger.debug('Converting queue into adjacency graph...')
             graph = get_deps_graph(packages)
-            logging.debug('Running Tarjan search...')
+            logger.debug('Running Tarjan search...')
             resolved = tarjan_search(graph, self.tree_dir, stage2)
             # Recheck after dependencies are loaded: a package whose deps hit
             # FAIL_ARCH is skipped the same way as one that is itself unbuildable.
@@ -273,7 +272,7 @@ class BuildCore(object):
                 resolved = self.reorder_deps(
                     [item for sublist in resolved for item in sublist], self.stage2)
         else:
-            logging.warning('Warning: Dependency resolution disabled!')
+            logger.warning('Warning: Dependency resolution disabled!')
             resolved = [[package] for package in packages]
         # print a newline
         print()
@@ -282,15 +281,14 @@ class BuildCore(object):
         for dep in resolved:
             if len(dep) > 1 or dep[0].name in dep[0].deps:
                 # this is a SCC, aka a loop
-                logging.error('Found a loop in the dependency graph: {}'.format(
-                    print_package_names(dep)))
+                logger.error(f'Found a loop in the dependency graph: {print_package_names(dep)}')
                 error = True
                 if self.reorder:
                     if not self.save_list:
-                        logging.warning(
+                        logger.warning(
                             'You probably want to add -p option to get a list of ordered packages.')
                     else:
-                        logging.info(
+                        logger.info(
                             'ACBS will still save the build queue. Please keep in mind that the build order inside the loop is not guaranteed.')
                         error = False
             if not error:
@@ -303,11 +301,11 @@ class BuildCore(object):
             check_package_groups(packages)
         return resolved
 
-    def build_sequential(self, build_timings, packages: List[ACBSPackageInfo]):
+    def build_sequential(self, build_timings, packages: list[ACBSPackageInfo]):
         # build process
         for idx, task in enumerate(packages):
             self.package_cursor += 1
-            logging.info(
+            logger.info(
                 f'Building {task.name} ({self.package_cursor}/{len(packages)})...')
             source_name = task.name
             if task.base_slug:
@@ -321,7 +319,7 @@ class BuildCore(object):
                     is_legacy = is_spec_legacy(spec_location)
                     checksum = generate_checksums(task.source_uri, is_legacy)
                     write_checksums(spec_location, checksum)
-                    logging.info(f'Updated checksum for {task.name}')
+                    logger.info(f'Updated checksum for {task.name}')
                 build_timings.append((task.name, -1))
                 continue
             if not task.build_location:
@@ -345,7 +343,7 @@ class BuildCore(object):
                         'Could not determine sub-directory, please specify manually.')
                 build_dir = os.path.join(build_dir, subdir)
             if task.installables and not self.generate_pkg_metadata:
-                logging.info('Installing dependencies from repository...')
+                logger.info('Installing dependencies from repository...')
                 install_from_repo(task.installables, self.force_use_apt)
             start = time.monotonic()
             task_name = f'{task.name} ({task.bin_arch} @ {task.epoch + ":" if task.epoch else ""}{task.version}-{task.rel})'
@@ -354,21 +352,20 @@ class BuildCore(object):
                 invoke_autobuild(task, build_dir, scoped_stage2, self.generate_pkg_metadata)
                 if not self.generate_pkg_metadata:
                     check_artifact(task.name, build_dir)
-            except Exception:
+            except Exception as exc:
                 # early printing of build summary before exploding
                 print_build_timings(build_timings, packages[idx:], time.monotonic() - start)
                 raise RuntimeError(
-                    f'Build directory of the failed package: {build_dir}')
+                    f'Build directory of the failed package: {build_dir}') from exc
             if not self.generate_pkg_metadata:
                 build_timings.append((task_name, time.monotonic() - start))
                 ciel_invalidate_cache()
                 ciel_wait_for_refresh()
 
     def acbs_except_hdr(self, type_, value, tb):
-        logging.debug('Traceback:\n' + ''.join(traceback.format_tb(tb)))
+        logger.debug('Traceback:\n' + ''.join(traceback.format_tb(tb)))
         if self.debug:
             sys.__excepthook__(type_, value, tb)
         else:
             print()
-            logging.fatal('Oops! \033[93m%s\033[0m: \033[93m%s\033[0m' % (
-                str(type_.__name__), str(value)))
+            logging.fatal('Oops! \033[93m%s\033[0m: \033[93m%s\033[0m', str(type_.__name__), str(value))

--- a/acbs/parser.py
+++ b/acbs/parser.py
@@ -3,13 +3,14 @@ import logging
 import os
 import re
 from collections import OrderedDict
-from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from acbs import bashvar
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
 from acbs.pm import filter_dependencies
 from acbs.utils import buildable, get_arch_name, get_archgroups, tarball_pattern
+
+logger = logging.getLogger(__name__)
 
 generate_mode = False
 
@@ -37,7 +38,7 @@ def parse_url_schema(url: str, checksum: str) -> ACBSSourceInfo:
             schema = 'git'
         else:
             raise ValueError(
-                'Unable to deduce source type for {}.'.format(url_plain))
+                f'Unable to deduce source type for {url_plain}.')
     elif len(url_split) < 3:
         schema = url_split[0].lower()
         url_plain = url_split[1]
@@ -48,7 +49,7 @@ def parse_url_schema(url: str, checksum: str) -> ACBSSourceInfo:
     acbs_source_info.type = 'tarball' if schema == 'tbl' else schema
     chksum_ = checksum.split('::', 1)
     if len(chksum_) != 2 and checksum != 'SKIP':
-        raise ValueError('Malformed checksum: {}'.format(checksum))
+        raise ValueError(f'Malformed checksum: {checksum}')
     acbs_source_info.chksum = (
         chksum_[0], chksum_[1]) if checksum != 'SKIP' else ('none', '')
     acbs_source_info.url = url_plain
@@ -70,9 +71,7 @@ def parse_fetch_options(options: str, acbs_source_info: ACBSSourceInfo):
             acbs_source_info.source_name = v.strip()
         elif k == 'use-url-name':
             acbs_source_info.use_url_name = v.strip() == 'true'
-        elif k == 'commit':
-            acbs_source_info.revision = v.strip()
-        elif k == 'version':
+        elif k == 'commit' or k == 'version':
             acbs_source_info.revision = v.strip()
         elif k == 'copy-repo':
             acbs_source_info.copy_repo = v.strip() == 'true'
@@ -88,23 +87,23 @@ def parse_fetch_options(options: str, acbs_source_info: ACBSSourceInfo):
     return acbs_source_info
 
 
-def get_var_arch(context: Dict[str, str], varname) -> Union[str, None]:
+def get_var_arch(context: dict[str, str], varname) -> str | None:
     try_names = []
     # Try to expand VARNAME__ARCH first.
-    try_names.append('{varname}__{arch}'.format(varname=varname, arch=arch.upper()))
+    try_names.append(f'{varname}__{arch.upper()}')
     # Then try expanding VARNAME__ARCHGROUP, e.g. VARNAME__RETRO.
-    try_names.extend(['{varname}__{group}'.format(varname=varname, group=g.upper()) for g in archgroups])
+    try_names.extend([f'{varname}__{g.upper()}' for g in archgroups])
     # Then try the VARNAME itself.
     try_names.append(varname)
     for try_name in try_names:
-        if try_name in context.keys():
+        if try_name in context:
             return context[try_name]
 
     return None
 
 
-def parse_package_url(var: Dict[str, str], ignore_empty_srcs: bool) -> List[ACBSSourceInfo]:
-    acbs_source_info: List[ACBSSourceInfo] = []
+def parse_package_url(var: dict[str, str], ignore_empty_srcs: bool) -> list[ACBSSourceInfo]:
+    acbs_source_info: list[ACBSSourceInfo] = []
     sources = get_var_arch(var, 'SRCS')
     checksums = get_var_arch(var, 'CHKSUMS')
     if var.get('DUMMYSRC') in ['y', 'yes', '1']:
@@ -136,7 +135,7 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
     # Ignore (seemingly) empty srcs on unbuildable archs, if the package
     # uses different sources for each (supported) architectures.
     ignore_empty_srcs: bool = False
-    logging.debug('Parsing {}...'.format(location))
+    logger.debug(f'Parsing {location}...')
     stage2 = ACBSPackageInfo.is_in_stage2(modifiers)
     # Call a helper function to check if there's a stage2 defines automatically
     defines_location = get_defines_file_path(location, stage2)
@@ -153,7 +152,7 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
         # We decided to make FAIL_ARCH to allow mainline by default.
         fail_arch = '!(mainline)'
     if not buildable(arch, fail_arch) and bin_arch != 'noarch':
-        logging.debug(f'Package {var["PKGNAME"]} is not buildable on current arch: {arch}. '
+        logger.debug(f'Package {var["PKGNAME"]} is not buildable on current arch: {arch}. '
                 'Any encountered empty SRCS will be ignored.')
         # Continue parsing but ignore any source error, since we still
         # need the complete tree.
@@ -162,10 +161,10 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
         # source info parser will fail, as there is no SRCS for current
         # arch.
         ignore_empty_srcs = True
-    deps: Optional[str] = get_var_arch(var, 'PKGDEP')
+    deps: str | None = get_var_arch(var, 'PKGDEP')
     # determine whether this is an undefined value or an empty string
     all_deps: str = '' if deps is None else deps
-    builddeps: Optional[str] = get_var_arch(var, 'BUILDDEP')
+    builddeps: str | None = get_var_arch(var, 'BUILDDEP')
     all_deps += ' ' + (builddeps or '')  # add builddep
     # architecture specific dependencies
     acbs_source_info = parse_package_url(spec_var, ignore_empty_srcs)
@@ -200,7 +199,7 @@ def parse_package(location: str, modifiers: str) -> ACBSPackageInfo:
     return filter_dependencies(result)
 
 
-def get_deps_graph(packages: List[ACBSPackageInfo]) -> 'OrderedDict[str, ACBSPackageInfo]':
+def get_deps_graph(packages: list[ACBSPackageInfo]) -> OrderedDict[str, ACBSPackageInfo]:
     'convert flattened list to adjacency list'
     result = {}
     for i in packages:
@@ -211,11 +210,11 @@ def get_deps_graph(packages: List[ACBSPackageInfo]) -> 'OrderedDict[str, ACBSPac
 def get_tree_by_name(filename: str, tree_name) -> str:
     acbs_config = configparser.ConfigParser(
         interpolation=configparser.ExtendedInterpolation())
-    with open(filename, 'rt') as conf_file:
-        try:
+    try:
+        with open(filename, 'rt') as conf_file:
             acbs_config.read_file(conf_file)
-        except Exception as ex:
-            raise Exception('Failed to read configuration file!') from ex
+    except configparser.Error as ex:
+            raise ValueError('Failed to read configuration file!') from ex
     try:
         tree_loc_dict = acbs_config[tree_name]
     except KeyError as ex:
@@ -225,8 +224,10 @@ def get_tree_by_name(filename: str, tree_name) -> str:
     try:
         tree_loc = tree_loc_dict['location']
     except KeyError as ex:
-        raise KeyError(
+        raise ValueError(
             'Malformed configuration file: missing `location` keyword') from ex
+    except configparser.Error as ex:
+        raise ValueError('Malformed configuration file') from ex
     return tree_loc
 
 

--- a/acbs/pm.py
+++ b/acbs/pm.py
@@ -2,13 +2,14 @@ import logging
 import re
 import shutil
 import subprocess
-from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 from acbs.base import ACBSPackageInfo
 from acbs.utils import get_arch_name
 
-installed_cache: Dict[str, bool] = {}
-available_cache: Dict[str, bool] = {}
+installed_cache: dict[str, bool] = {}
+available_cache: dict[str, bool] = {}
 use_native_bindings: bool = True
 reorder_mode: bool = False
 
@@ -23,7 +24,7 @@ except ImportError:
     apt_check_if_available = None
 
 
-def enable_reorder_mode(enable: Optional[bool]=None) -> bool:
+def enable_reorder_mode(enable: bool | None=None) -> bool:
     global reorder_mode
     if enable is not None:
         reorder_mode = enable
@@ -54,12 +55,12 @@ def escape_package_name(name: str) -> str:
 
 def escape_package_name_install(name: str) -> str:
     escaped = escape_package_name(name)
-    if escaped.endswith('+') or escaped.endswith('-'):
+    if escaped.endswith(('+', '-')):
         return f'{escaped}+'
     return escaped
 
 
-def fix_pm_states(escaped: List[str]):
+def fix_pm_states(escaped: list[str]):
     count = 0
     while count < 3:
         try:
@@ -77,13 +78,13 @@ def fix_pm_states(escaped: List[str]):
 
 
 def check_if_installed(name: str) -> bool:
-    logging.debug('Checking if %s is installed' % name)
+    logger.debug('Checking if %s is installed', name)
     cached = installed_cache.get(name)
     if cached is not None:
         return cached
     if use_native_bindings:
         assert callable(apt_check_if_available)
-        logging.debug('... using libapt-pkg')
+        logger.debug('... using libapt-pkg')
         result = apt_check_if_available(name)
         if result == 0:
             installed_cache[name] = True
@@ -111,19 +112,19 @@ def check_if_installed(name: str) -> bool:
 
 
 def check_if_available(name: str) -> bool:
-    logging.debug('Checking if %s is available' % name)
+    logger.debug('Checking if %s is available', name)
     cached = available_cache.get(name)
     if cached is not None:
         return cached
     if use_native_bindings:
         assert callable(apt_check_if_available)
-        logging.debug('... using libapt-pkg')
+        logger.debug('... using libapt-pkg')
         if apt_check_if_available(name) != 1:
             return False
     try:
         subprocess.check_output(
             ['apt-cache', 'show', escape_package_name(name)], stderr=subprocess.STDOUT)
-        logging.debug('Checking if %s can be installed' % name)
+        logger.debug('Checking if %s can be installed', name)
         subprocess.check_output(
             ['apt-get', 'install', '-s', name], stderr=subprocess.STDOUT, env={'DEBIAN_FRONTEND': 'noninteractive'})
         available_cache[name] = True
@@ -133,7 +134,7 @@ def check_if_available(name: str) -> bool:
         return False
 
 
-def install_from_repo(packages: List[str], force_use_apt=False):
+def install_from_repo(packages: list[str], force_use_apt=False):
     # FIXME: RISC-V build hosts is unreliable when using oma: random lock-ups
     # during `oma refresh'. Disabling oma to workaround potential lock-ups.
     oma_exists = False
@@ -145,8 +146,8 @@ def install_from_repo(packages: List[str], force_use_apt=False):
     return install_from_repo_oma(packages) or install_from_repo_apt(packages)
 
 
-def install_from_repo_apt(packages: List[str]):
-    logging.debug('Installing %s' % packages)
+def install_from_repo_apt(packages: list[str]):
+    logger.debug('Installing %s', packages)
     escaped = []
     for package in packages:
         escaped.append(escape_package_name_install(package))
@@ -155,20 +156,19 @@ def install_from_repo_apt(packages: List[str]):
     try:
         subprocess.check_call(command, env={'DEBIAN_FRONTEND': 'noninteractive'})
     except subprocess.CalledProcessError:
-        logging.warning(
+        logger.warning(
             'Failed to install dependencies, attempting to correct issues...')
         fix_pm_states(escaped)
-    return
 
 
-def install_from_repo_oma(packages: List[str]) -> bool:
-    logging.debug('Installing %s from oma' % packages)
+def install_from_repo_oma(packages: list[str]) -> bool:
+    logger.debug('Installing %s from oma', packages)
     command = ['oma', 'install', '-y', '--force-confnew', '--no-progress', '--force-unsafe-io', '--no-bell', '--no-clean']
     command.extend(packages)
     try:
         subprocess.check_call(command)
     except subprocess.CalledProcessError:
-        logging.warning(
+        logger.warning(
             'Failed to use oma install dependencies, fallbacking to apt...')
         return False
     return True

--- a/acbs/query.py
+++ b/acbs/query.py
@@ -1,11 +1,11 @@
 import os
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 from acbs.const import CONF_DIR, DUMP_DIR, LOG_DIR, TMP_DIR
 from acbs.parser import get_tree_by_name
 
 
-def acbs_query(input: str) -> Optional[str]:
+def acbs_query(input: str) -> str | None:
     input = input.strip()
     if not input:
         return None
@@ -19,16 +19,16 @@ def acbs_query(input: str) -> Optional[str]:
     return getter(commands)
 
 
-def acbs_query_tree(commands: Sequence[str]) -> Optional[str]:
+def acbs_query_tree(commands: Sequence[str]) -> str | None:
     if len(commands) != 2:
         return None
     try:
         return get_tree_by_name(os.path.join(CONF_DIR, 'forest.conf'), commands[1])
-    except Exception:
+    except (OSError, ValueError):
         return None
 
 
-def acbs_query_path(commands: Sequence[str]) -> Optional[str]:
+def acbs_query_path(commands: Sequence[str]) -> str | None:
     if len(commands) != 2:
         return None
     return {

--- a/acbs/resume.py
+++ b/acbs/resume.py
@@ -1,6 +1,5 @@
 import logging
 import pickle
-from typing import Dict, List
 
 from acbs import __version__
 from acbs.base import ACBSPackageInfo, ACBSShrinkWrap
@@ -11,9 +10,10 @@ from acbs.main import BuildCore
 from acbs.pm import check_if_installed
 from acbs.utils import make_build_dir, print_build_timings, print_package_names
 
+logger = logging.getLogger(__name__)
 
-def reassign_build_dir(packages: List[ACBSPackageInfo]):
-    groups: Dict[str, str] = {}
+def reassign_build_dir(packages: list[ACBSPackageInfo]):
+    groups: dict[str, str] = {}
     for package in packages:
         if package.base_slug:
             directory = groups.get(package.base_slug)
@@ -23,13 +23,12 @@ def reassign_build_dir(packages: List[ACBSPackageInfo]):
             package.build_location = directory
             continue
         package.build_location = ''
-    return
 
 
-def check_dpkg_state(state: ACBSShrinkWrap, packages: List[ACBSPackageInfo]) -> bool:
+def check_dpkg_state(state: ACBSShrinkWrap, packages: list[ACBSPackageInfo]) -> bool:
     if checkpoint_dpkg() == state.dpkg_state:
         return True
-    logging.warning('DPKG state change detected. Re-checking dependencies...')
+    logger.warning('DPKG state change detected. Re-checking dependencies...')
     for package in packages:
         if not check_if_installed(package.name):
             return False
@@ -43,33 +42,32 @@ def do_load_checkpoint(name: str) -> ACBSShrinkWrap:
 
 def do_resume_checkpoint(filename: str, args):
     def resume_build():
-        logging.debug('Queue: {}'.format(resumed_packages))
-        logging.info('Packages to be resumed: {}'.format(
-            print_package_names(resumed_packages, 5)))
+        logger.debug(f'Queue: {resumed_packages}')
+        logger.info(f'Packages to be resumed: {print_package_names(resumed_packages, 5)}')
         build_timings = state.timings.copy()
         try:
             builder.build_sequential(build_timings, resumed_packages)
-        except Exception as ex:
+        except Exception:
             # failed again?
-            logging.exception(ex)
+            logger.exception("Failed to resume build")
             builder.save_checkpoint(build_timings, resumed_packages)
         print_build_timings(build_timings, [])
 
     state = do_load_checkpoint(filename)
     builder = BuildCore(args)
     stage2 = builder.stage2
-    logging.info('Resuming from {}'.format(filename))
+    logger.info(f'Resuming from {filename}')
     if state.version != __version__:
-        logging.warning(
+        logger.warning(
             'The state was check-pointed with a different version of acbs!')
-        logging.warning('Undefined behavior might occur!')
+        logger.warning('Undefined behavior might occur!')
     if state.no_deps:
         leftover = state.packages[state.cursor-1:]
-        logging.warning('Resuming without dependency resolution.')
-        logging.info('Resumed. {} packages to go.'.format(len(leftover)))
+        logger.warning('Resuming without dependency resolution.')
+        logger.info(f'Resumed. {len(leftover)} packages to go.')
         builder.build_sequential(state.timings, leftover)
         return
-    logging.info('Validating status...')
+    logger.info('Validating status...')
     if len(state.packages) != len(state.sps):
         raise ValueError(
             'Inconsistencies detected in the saved state! The file might be corrupted.')
@@ -82,24 +80,23 @@ def do_resume_checkpoint(filename: str, args):
             index += 1
             continue
         # the spec files changed
-        if index < new_cursor:
-            new_cursor = index
+        new_cursor = min(new_cursor, index)
         resumed_packages.extend(find_package(p.name, builder.tree_dir, '+stage2' if stage2 else ''))
         # index doesn't matter now, since changes have been detected
     if not check_dpkg_state(state, resumed_packages[:new_cursor]):
         name = checkpoint_to_group(
             resumed_packages[new_cursor:], builder.tree_dir)
         raise RuntimeError(
-            'DPKG state mismatch. Unable to resume.\nACBS has created a new temporary group {} for you to continue.'.format(name))
+            f'DPKG state mismatch. Unable to resume.\nACBS has created a new temporary group {name} for you to continue.')
     resumed_packages = resumed_packages[new_cursor:]
     # clear the build directory of the first package
     reassign_build_dir(resumed_packages)
     if new_cursor != (state.cursor - 1):
-        logging.warning(
+        logger.warning(
             'Scenario mismatch detected! Dependency resolution will be re-attempted.')
         resolved = builder.resolve_deps(resumed_packages, stage2)
-        logging.info(
-            'Dependencies resolved, {} packages in the queue'.format(len(resolved)))
+        logger.info(
+            f'Dependencies resolved, {len(resolved)} packages in the queue')
         resume_build()
         return
     resume_build()

--- a/acbs/utils.py
+++ b/acbs/utils.py
@@ -8,13 +8,14 @@ import signal
 import subprocess
 import tempfile
 import time
-
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import cast
 
 from acbs import __version__
 from acbs.ab4cfg import get_arch_override
 from acbs.base import ACBSPackageInfo, ACBSSourceInfo
+from acbs.bashvar import ParseException
 from acbs.const import (
     ANSI_BROWN,
     ANSI_GREEN,
@@ -26,6 +27,8 @@ from acbs.const import (
     AUTOBUILD_DIR,
 )
 from acbs.crypto import check_hash_hashlib_inner
+
+logger = logging.getLogger(__name__)
 
 build_logging = False
 INCLUDE = 0
@@ -39,8 +42,8 @@ except ImportError:
 
 chksum_pattern = re.compile(r"CHKSUM(?:S)?=['\"].*?['\"]", flags=re.MULTILINE | re.DOTALL)
 tarball_pattern = re.compile(r'\.(tar\..+|cpio\..+)', flags=re.MULTILINE | re.DOTALL)
-SIGNAMES = dict((k, v) for v, k in reversed(sorted(signal.__dict__.items()))
-                if v.startswith('SIG') and not v.startswith('SIG_'))
+SIGNAMES = {k:v for v, k in sorted(signal.__dict__.items(), reverse=True)
+                if v.startswith('SIG') and not v.startswith('SIG_')}
 
 
 def validate_package_name(package_name: str) -> bool:
@@ -55,7 +58,7 @@ def validate_package_name(package_name: str) -> bool:
     return re.match(r'^[a-z0-9][a-z0-9\-+\.]*$', package_name) is not None
 
 
-def guess_extension_name_from_contents(filename: str) -> Optional[str]:
+def guess_extension_name_from_contents(filename: str) -> str | None:
     from acbs import magic
     checker = magic.open(magic.MAGIC_MIME_TYPE)
     result = checker.file(filename)
@@ -96,7 +99,7 @@ def guess_extension_name(filename: str) -> str:
         if not extensions:
             try:
                 return guess_extension_name_from_contents(filename) or ''
-            except Exception:
+            except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
                 return ''
         else:
             # strip out query parameters
@@ -106,7 +109,7 @@ def guess_extension_name(filename: str) -> str:
     return extension
 
 
-def get_arch_name() -> Optional[str]:
+def get_arch_name() -> str | None:
     """
     Detect architecture of the host machine
 
@@ -115,16 +118,18 @@ def get_arch_name() -> Optional[str]:
     abcfg_path = os.path.join(AUTOBUILD_CONF_DIR, 'ab4cfg.sh')
     try:
         arch_override = get_arch_override(abcfg_path)
-        if arch_override:
-            return arch_override
-        output = subprocess.check_output(['dpkg', '--print-architecture'])
-        return output.decode('utf-8').strip()
-    except Exception:
+    except (OSError, ParseException):
+        arch_override = None
+    if arch_override:
+        return arch_override
+    try:
+        output = subprocess.check_output(['dpkg', '--print-architecture'], text=True)
+        return output.strip()
+    except (OSError, subprocess.CalledProcessError):
         return None
-    return None
 
 
-def get_archgroups(arch: Union[str, None]=None) -> List[str]:
+def get_archgroups(arch: str | None=None) -> list[str]:
     """
     Get all defined architecture groups for the host machine
 
@@ -142,13 +147,17 @@ def get_archgroups(arch: Union[str, None]=None) -> List[str]:
     archgroup_path = Path(AUTOBUILD_DIR) / 'sets' / 'arch_groups.json'
     archgroup_data: dict[str, list[str]] = {}
     try:
-        fd = open(archgroup_path, 'r')
-        archgroup_data.update(json.load(fd))
-    except Exception as e:
-        logging.warning("Unable to read arch group data from Autobuild4: {}".format(e))
+        with open(archgroup_path, 'r') as fp:
+            data = json.load(fp)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logger.warning(f"Unable to read arch group data from Autobuild4: {exc}")
         return groups
+    if not isinstance(data, dict):
+        logger.warning("Invalid arch group data from Autobuild4: expected a JSON object")
+        return groups
+    archgroup_data.update(data)
 
-    groups.extend([x for x in archgroup_data.keys() if arch in archgroup_data[x]])
+    groups.extend([x for x in archgroup_data if arch in archgroup_data[x]])
 
     return groups
 
@@ -161,10 +170,10 @@ def full_line_banner(msg: str, char='-') -> str:
     """
     bars_count = int((shutil.get_terminal_size().columns - len(msg) - 2) / 2)
     bars = char*bars_count
-    return ' '.join((bars, msg, bars))
+    return f'{bars} {msg} {bars}'
 
 
-def print_package_names(packages: List[ACBSPackageInfo], limit: Optional[int] = None) -> str:
+def print_package_names(packages: list[ACBSPackageInfo], limit: int | None = None) -> str:
     """
     Print out the names of packages
 
@@ -176,8 +185,7 @@ def print_package_names(packages: List[ACBSPackageInfo], limit: Optional[int] = 
     if limit is not None and len(packages) > limit:
         pkgs = packages[:limit]
     printable_packages = [pkg.name for pkg in pkgs]
-    more_messages = ' ... and {} more'.format(
-        len(packages) - limit) if limit and limit < len(packages) else ''
+    more_messages = f' ... and {len(packages) - limit} more' if limit and limit < len(packages) else ''
     return ', '.join(printable_packages) + more_messages
 
 
@@ -185,7 +193,7 @@ def make_build_dir(path: str) -> str:
     return tempfile.mkdtemp(dir=path, prefix='acbs.')
 
 
-def guess_subdir(path: str) -> Optional[str]:
+def guess_subdir(path: str) -> str | None:
     name = None
     count = 0
     for subdir in os.scandir(path):
@@ -203,9 +211,9 @@ def has_stamp(path: str) -> bool:
     return os.path.exists(os.path.join(path, '.acbs-stamp'))
 
 
-def start_build_capture(env: Dict[str, str], build_dir: str):
+def start_build_capture(env: dict[str, str], build_dir: str):
     with tempfile.NamedTemporaryFile(prefix='acbs-build_', suffix='.log', dir=build_dir, delete=False) as f:
-        logging.info(f'Build log: {f.name}')
+        logger.info(f'Build log: {f.name}')
         header = f'!!ACBS Build Log\n!!Build start: {time.ctime()}\n'
         f.write(header.encode())
         assert pexpect
@@ -228,7 +236,7 @@ def start_build_capture(env: Dict[str, str], build_dir: str):
         if signal_status or exit_status:
             raise RuntimeError('autobuild4 did not exit successfully.')
 
-def start_general_autobuild_metadata(env: Dict[str, str], script_location: str, package_name: str, build_dir: str):
+def start_general_autobuild_metadata(env: dict[str, str], script_location: str, package_name: str, build_dir: str):
     env["AB_WRITE_METADATA"] = "1"
     subprocess.check_call(['autobuild', '-p'], env=env)
 
@@ -239,7 +247,7 @@ def start_general_autobuild_metadata(env: Dict[str, str], script_location: str, 
         path = os.path.join(script_location, '..', f'.srcinfo-{package_name}.json')
 
     shutil.copyfile(os.path.join(build_dir, '.srcinfo.json'), path)
-    logging.info(f".srcinfo.json saved to: {path}")
+    logger.info(f".srcinfo.json saved to: {path}")
 
 def generate_metadata(task: ACBSPackageInfo) -> str:
     tree_commit = 'unknown'
@@ -247,7 +255,7 @@ def generate_metadata(task: ACBSPackageInfo) -> str:
         tree_commit = subprocess.check_output(
             ['git', '-c', 'safe.directory=/tree', 'describe', '--always', '--dirty'], cwd=task.script_location).decode('utf-8').strip()
     except subprocess.CalledProcessError as ex:
-        logging.warning(f'Could not determine tree commit: {ex}')
+        logger.warning(f'Could not determine tree commit: {ex}')
     return f'X-AOSC-ACBS-Version: {__version__}\nX-AOSC-Commit: {tree_commit}\n'
 
 
@@ -256,7 +264,7 @@ def generate_version_stamp(task: ACBSPackageInfo) -> str:
         head_ref = subprocess.check_output(
             ['git', '-c', 'safe.directory=/tree', 'symbolic-ref', 'HEAD'], cwd=task.script_location).decode('utf-8').strip()
         if head_ref == 'refs/heads/stable':
-            logging.info('Not using pre-release version stamp')
+            logger.info('Not using pre-release version stamp')
             return ''
 
         dirty = len(subprocess.check_output(
@@ -268,15 +276,15 @@ def generate_version_stamp(task: ACBSPackageInfo) -> str:
             timestamp = int(subprocess.check_output(
                 ['git', '-c', 'safe.directory=/tree', 'show', '-s', '--format=%ct', 'HEAD'], cwd=task.script_location).decode('utf-8').strip())
         stamp = (
-            datetime.datetime.utcfromtimestamp(timestamp)
+            datetime.datetime.fromtimestamp(timestamp, datetime.UTC)
             .strftime('~pre%Y%m%dT%H%M%SZ')
         )
         if dirty:
             stamp += '~dirty'
-        logging.info(f'Using version stamp: {stamp}')
+        logger.info(f'Using version stamp: {stamp}')
         return stamp
     except subprocess.CalledProcessError as ex:
-        logging.warning(f'Could not determine version stamp: {ex}')
+        logger.warning(f'Could not determine version stamp: {ex}')
         return ''
 
 
@@ -290,7 +298,7 @@ def check_artifact(name: str, build_dir: str):
     for f in os.listdir(build_dir):
         if f.endswith('.deb') and f.startswith(name):
             return
-    logging.error(
+    logger.error(
         f'{ANSI_RED}Autobuild malfunction! Emergency drop!{ANSI_RST}')
     raise RuntimeError(
         'STOP! Autobuild3 malfunction detected! Returned zero status with no artifact.')
@@ -314,8 +322,7 @@ def invoke_autobuild(task: ACBSPackageInfo, build_dir: str, stage2: bool, genera
     if stage2 and os.path.exists(os.path.join(build_dir, 'autobuild', 'defines.stage2')):
         defines_file = 'defines.stage2'
     with open(os.path.join(build_dir, 'autobuild', defines_file), 'at') as f:
-        f.write('\nPKGREL=\'{}\'\nPKGVER=\'{}\'\nif [ -f \'{}\' ];then source \'{}\' && abinfo "Injected ACBS definitions";fi\n'.format(
-            task.rel, task.version, acbs_helper, acbs_helper))
+        f.write(f'\nPKGREL=\'{task.rel}\'\nPKGVER=\'{task.version}\'\nif [ -f \'{acbs_helper}\' ];then source \'{acbs_helper}\' && abinfo "Injected ACBS definitions";fi\n')
         if task.epoch:
             f.write(f'PKGEPOCH=\'{task.epoch}\'')
     with open(os.path.join(build_dir, 'autobuild', 'extra-dpkg-control'), 'wt') as f:
@@ -327,7 +334,7 @@ def invoke_autobuild(task: ACBSPackageInfo, build_dir: str, stage2: bool, genera
         else:
             start_general_autobuild_metadata(env_dict, task.script_location, task.name, build_dir)
         return
-    logging.warning(
+    logger.warning(
         'Build logging not available due to pexpect not installed.')
     subprocess.check_call(['autobuild'], env=env_dict)
 
@@ -339,33 +346,28 @@ def human_time(full_seconds: float) -> str:
     """
     if full_seconds < 0:
         return 'Download only'
-    out_str_tmp = '{}'.format(
-        datetime.timedelta(seconds=full_seconds))
+    out_str_tmp = f'{datetime.timedelta(seconds=full_seconds)}'
     out_str = out_str_tmp.replace(
         ':', f'{ANSI_GREEN}:{ANSI_RST}')
     return out_str
 
 
-def format_column(data: Sequence[Tuple[str, ...]]) -> str:
-    output = ''
+def format_column(data: Sequence[tuple[str, ...]]) -> str:
     col_width = max(len(str(word)) for row in data for word in row)
-    for row in data:
-        output = '%s%s\n' % (
-            output, ('\t'.join(str(word).ljust(col_width) for word in row)))
-    return output
+    return '\n'.join('\t'.join(str(word).ljust(col_width) for word in row) for row in data) + '\n'
 
 
 def format_package_name(package: ACBSPackageInfo) -> str:
     return f'{package.name} ({package.bin_arch} @ {package.epoch + ":" if package.epoch else ""}{package.version}-{package.rel})'
 
 
-def print_build_timings(timings: List[Tuple[str, float]], failed_packages: List[ACBSPackageInfo], last_build_time: float=0.0):
+def print_build_timings(timings: list[tuple[str, float]], failed_packages: list[ACBSPackageInfo], last_build_time: float=0.0):
     """
     Print the build statistics
 
     :param timings: List of timing data
     """
-    formatted_timings: List[Tuple[str, str]] = []
+    formatted_timings: list[tuple[str, str]] = []
     formatted_failed_packages = [format_package_name(pkg) for pkg in failed_packages]
     banner = '=' * 40
     print(f"\n{banner}")
@@ -383,7 +385,7 @@ def print_build_timings(timings: List[Tuple[str, float]], failed_packages: List[
     if len(failed_packages) > 1:
         print("Package(s) not built due to previous build failure:")
         print('\n'.join(formatted_failed_packages[1:]))
-        print('')
+        print()
 
 
 def is_spec_legacy(spec: str) -> bool:
@@ -392,7 +394,7 @@ def is_spec_legacy(spec: str) -> bool:
     return content.find('SRCS=') < 0
 
 
-def generate_checksums(info: List[ACBSSourceInfo], legacy=False) -> str:
+def generate_checksums(info: list[ACBSSourceInfo], legacy=False) -> str:
     def calculate_checksum(o: ACBSSourceInfo):
         if not o.source_location:
             raise ValueError('source_location is None.')
@@ -427,10 +429,9 @@ def write_checksums(spec: str, checksums: str):
         content = content.rstrip() + "\n" + checksums + "\n"
     with open(spec, 'wt') as f:
         f.write(content)
-    return
 
 
-def fail_arch_regex(expr: str) -> Tuple[int, re.Pattern]:
+def fail_arch_regex(expr: str) -> tuple[int, re.Pattern]:
     regex = '^('
 
     if len(expr) < 3:
@@ -442,7 +443,7 @@ def fail_arch_regex(expr: str) -> Tuple[int, re.Pattern]:
     elif expr[0] == '@' and expr[1] == '(':
         mode = INCLUDE
     elif re.search('[^0-9a-z_-]', expr) is not None or expr[1:].strip('()') == expr:
-        raise Exception(f'Invalid FAIL_ARCH expression: "{expr}". Refer to bash(1) § Pattern Matching for details.')
+        raise ValueError(f'Invalid FAIL_ARCH expression: "{expr}". Refer to bash(1) § Pattern Matching for details.')
     else:
         # Disallow build for one specific archgroup/target.
         return (INCLUDE, re.compile(f'^{expr}$'))
@@ -462,7 +463,7 @@ def buildable(arch, exp) -> bool:
                 return False
             if mode == EXCLUDE:
                 return True
-    return True if mode == INCLUDE else False
+    return mode == INCLUDE
 
 
 class ACBSLogFormatter(logging.Formatter):
@@ -481,7 +482,7 @@ class ACBSLogFormatter(logging.Formatter):
         if record.levelno in (logging.WARNING, logging.ERROR, logging.CRITICAL,
                               logging.INFO, logging.DEBUG):
             record.msg = f'[{lvl_map[record.levelname]}]: \033[1m{record.msg}\033[0m'
-        return super(ACBSLogFormatter, self).format(record)
+        return super().format(record)
 
 
 class ACBSLogPlainFormatter(logging.Formatter):
@@ -501,4 +502,4 @@ class ACBSLogPlainFormatter(logging.Formatter):
         if record.levelno in (logging.WARNING, logging.ERROR, logging.CRITICAL,
                               logging.INFO, logging.DEBUG):
             record.msg = f'[{lvl_map[record.levelname]}]: {record.msg}'
-        return super(ACBSLogPlainFormatter, self).format(record)
+        return super().format(record)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-#
 # acbs documentation build configuration file, created by
 # sphinx-quickstart on Sun Jul 31 18:23:52 2016.
 #

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,7 +31,7 @@ Requirements
 
 Mandatory dependencies:
 
-* Python 3 (>= 3.6): Running the program itself.
+* Python 3 (>= 3.14): Running the program itself.
 * GNU File (libmagic): File type detection.
 * LibArchive (bsdtar): Archive handling.
 * GNU Wget or Aria2: Source downloading.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.2.0", "pybind11>=2.5.0"]
+requires = ["setuptools>=68.2.0", "pybind11>=3.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages]
@@ -18,7 +18,7 @@ authors = [{ name = "liushuyu", email = "liushuyu@aosc.io" }]
 description = "AOSC CI Building System"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.14"
 dependencies = ["pyparsing>=2.4,<4"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -30,13 +30,13 @@ urls = { "Repository" = "https://github.com/AOSC-Dev/acbs" }
 
 [project.optional-dependencies]
 logging = ["pexpect"]
-dev = ["pyright", "ruff", "setuptools", "pybind11>=2.5.0", "pexpect"]
+dev = ["pyright", "ruff", "setuptools", "pybind11>=3.0.0", "pexpect"]
 
 [tool.ruff]
 line-length = 127
-target-version = "py38"
 [tool.ruff.lint.mccabe]
 max-complexity = 5
 
 [tool.pyright]
+pythonVersion = "3.14"
 exclude = ["build", "dist", "venv", ".venv"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import Extension, setup
 
 
-class get_pybind_include(object):
+class get_pybind_include:
     """Helper class to determine the pybind11 include path
     The purpose of this class is to postpone importing pybind11
     until it is actually installed, so that the ``get_include()``

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import acbs.pm
 from acbs.const import TMP_DIR
 from acbs.deps import tarjan_search
 from acbs.parser import get_deps_graph, parse_url_schema
-from acbs.utils import INCLUDE, EXCLUDE, fail_arch_regex, guess_extension_name, make_build_dir
+from acbs.utils import EXCLUDE, INCLUDE, fail_arch_regex, guess_extension_name, make_build_dir
 
 
 def fake_pm(package):
@@ -75,9 +75,9 @@ class TestParser(unittest.TestCase):
 
     def test_fail_arch(self):
         import re
-        self.assertRaises(Exception, fail_arch_regex, "!amd64")
-        self.assertRaises(Exception, fail_arch_regex, "amd64|arm64")
-        self.assertRaises(Exception, fail_arch_regex, "(amd64|arm64)")
+        self.assertRaises(ValueError, fail_arch_regex, "!amd64")
+        self.assertRaises(ValueError, fail_arch_regex, "amd64|arm64")
+        self.assertRaises(ValueError, fail_arch_regex, "(amd64|arm64)")
         self.assertEqual((INCLUDE, re.compile("^amd64$")), fail_arch_regex("amd64"))
         self.assertEqual((INCLUDE, re.compile("^(amd64|arm64)$")), fail_arch_regex("@(amd64|arm64)"))
         self.assertEqual((EXCLUDE, re.compile("^(amd64|arm64)$")), fail_arch_regex("!(amd64|arm64)"))

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,138 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "acbs"
+source = { editable = "." }
+dependencies = [
+    { name = "pyparsing" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pexpect" },
+    { name = "pybind11" },
+    { name = "pyright" },
+    { name = "ruff" },
+    { name = "setuptools" },
+]
+logging = [
+    { name = "pexpect" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pexpect", marker = "extra == 'dev'" },
+    { name = "pexpect", marker = "extra == 'logging'" },
+    { name = "pybind11", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pyparsing", specifier = ">=2.4,<4" },
+    { name = "pyright", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "setuptools", marker = "extra == 'dev'" },
+]
+provides-extras = ["logging", "dev"]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pybind11"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/f3/95b0f40b31df41dbfe6bb0857419c9442c15839cbac4796f1c26ae0b6081/pybind11-3.1.0.tar.gz", hash = "sha256:a1cc06b524ab3edca51f8ad3895f9c4fa20b8b19283173dff4ae781449dc9639", size = 603746, upload-time = "2026-08-06T23:33:00.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/fd/8762f7ee3e4e4be6d1d846cffb4916dd9bb02b2f800d3603718a0efe494c/pybind11-3.1.0-py3-none-any.whl", hash = "sha256:b8488090f8acffbcb6b5d6a85571a6827a0a2981ffb75e5a0b27b87c4a6b7dd0", size = 319402, upload-time = "2026-08-06T23:32:59.047Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/8f/d8074b1f25e003164087a8bfe79a0f1a3945135764dbb6aaab04103dcaf9/ruff-0.16.4.tar.gz", hash = "sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc", size = 4899731, upload-time = "2026-08-20T17:43:59.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/80/779895ef584e089d22f2c6df0d0e99a65ec2df0805f1fffd439415b8c1f0/ruff-0.16.4-py3-none-linux_armv6l.whl", hash = "sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7", size = 10006909, upload-time = "2026-08-20T17:43:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/f553199b5e8927a05cb5c422d921fd0656b29ab976e91c44802107c6b0da/ruff-0.16.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604", size = 10240201, upload-time = "2026-08-20T17:43:19.337Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/70/4a6dc4bb34da4dee35e30f09bbd1bfbdd26f33b62fb9b8df31f08a199cd2/ruff-0.16.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255", size = 9835122, upload-time = "2026-08-20T17:43:21.708Z" },
+    { url = "https://files.pythonhosted.org/packages/24/12/c6e22d686372c15bcb7af99831f1a1be96df696491babf4f24e4f942c527/ruff-0.16.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade", size = 9977162, upload-time = "2026-08-20T17:43:24.236Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/72b10ec912f5ab5854992eaf7aa7cd36729b6937d9dc4e0fb41b3bf428ec/ruff-0.16.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff", size = 9829789, upload-time = "2026-08-20T17:43:26.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/80/0f30e32e7f6ee26edc39075502db9d368d788a44a79b55f763eb4ab03796/ruff-0.16.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80", size = 10527949, upload-time = "2026-08-20T17:43:29.384Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3d/86e8ad3542169e56cac3859a343afdb9df2ad54d35a59ce1e67baee83421/ruff-0.16.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07", size = 11333695, upload-time = "2026-08-20T17:43:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/16/481c29b380c20a0054a8261066665e1b3488e23636c49d0a43e75975b9bb/ruff-0.16.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7", size = 10727741, upload-time = "2026-08-20T17:43:34.596Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b6/56bc0b8cf45b54b28b3a5e6381c8945d51b5b18adf659454c32295209a31/ruff-0.16.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3", size = 10286522, upload-time = "2026-08-20T17:43:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/8b/b345b4fb110f2fbe2bd31eabd271e5e8b3b7e4ee6c0e02f2dc6be78db000/ruff-0.16.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454", size = 10584182, upload-time = "2026-08-20T17:43:39.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/e5/827b34041c35f58774a9681a4213994c164fc987800f4dddabcf451da0bf/ruff-0.16.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b", size = 10134195, upload-time = "2026-08-20T17:43:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/d0bffcdd6729b87afc82ba0ef377173356a7dc8e972f5179968cf2fdf98c/ruff-0.16.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d", size = 9825821, upload-time = "2026-08-20T17:43:44.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/32/0db2a863b796ca62d83e92a07a3ccf00921b14db02059347576a2fda3d4b/ruff-0.16.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0", size = 10267658, upload-time = "2026-08-20T17:43:46.989Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a0/fbdeb59e48c6261f523e56c8f12e9c08fbe693786595cc7e3959207a9232/ruff-0.16.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d", size = 10697071, upload-time = "2026-08-20T17:43:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/28/0c6dd865859c6d17bc8ccc34cb72b0e02d6c7eb25e8a1e22b5bea681e2c0/ruff-0.16.4-py3-none-win32.whl", hash = "sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e", size = 10021687, upload-time = "2026-08-20T17:43:52.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/e724450f621698117f9aa6dd241c94d0274ae96781378dc86745ae29f0e7/ruff-0.16.4-py3-none-win_amd64.whl", hash = "sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c", size = 10567657, upload-time = "2026-08-20T17:43:54.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/fe/da8b9e1347696bb22120b77280ec5ce25d500ca5cb39d5ad6e5c18de19c1/ruff-0.16.4-py3-none-win_arm64.whl", hash = "sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21", size = 10451579, upload-time = "2026-08-20T17:43:57.135Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]


### PR DESCRIPTION
1. Bump Required Python to 3.14
2. Use latest version of actions.
3. Update the way CI handle `uv`
4. Add lockfile
5. Apply `uv check --fix` patches
6. Some manual micro refactors in single function.

Most difference comes from `uv check --fix`.